### PR TITLE
Update jQuery

### DIFF
--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -7,7 +7,7 @@
 // @include        http://www.icheckmovies.com*
 // @include        https://icheckmovies.com*
 // @include        https://www.icheckmovies.com*
-// @require        http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js
+// @require        http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js
 // @grant          GM_setValue
 // @grant          GM_getValue
 // @grant          GM_addStyle


### PR DESCRIPTION
Hi!

jQuery 1.6.2 is quite outdated by now, and including the full library in the code isn't necessary since GM ~1.0. Only few fixes were needed to update it to 1.11.1, 945010fb214052ff9c76e8571c5e50f98fbb1d51 - use boolean attributes with .prop(), c99ff228b5d0a33197f39db1490b8678113035db - attach event handlers with .on(), d9574dc89ea8452f7bca75445be19cbd45830bc1 - careful parsing of HTML with $.(). 

I also updated two jQ plugins. I have checked most of the script's functionality in FF+GM and GC+TM, and it seems to be working fine. [jquery-migrate](https://github.com/jquery/jquery-migrate) shows no warnings.
