### PR TITLE
Simpler configs

### DIFF
--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -75,12 +75,11 @@ function setProperty(path, obj, val) {
 // ff+gm: uneval for obj: ({a:5})
 // gc+tm: uneval for obj: $1 = {"a":5};
 function evalOrParse(str) {
-    var bounds = str.charAt(0) + str.charAt(str.length-1);
-    if (bounds !== "{}" && bounds !== "[]") {
+    try {
+        return JSON.parse(str);
+    } catch (e) {
         console.log('Converting from old storage mode with spooky eval');
         return eval(str);
-    } else {
-        return JSON.parse(str);
     }
 }
 


### PR DESCRIPTION
This change may be less self-evident than two previous ones, and I would understand if you don't want to merge it. I didn't like that in order to extend the script, I had to make changes in several distant parts of it: 
1. Default settings in `ICM_Config.prototype.Init`
2. Includes/excludes regexes in `ICM_MyModule` constructor
3. Duplicate module config index when registering module: 

``` javascript
app.register(new ICM_MyModule(config.Get("my_module")));
```

Not only was it cumbersome, but it was also prone to bugs due to duplicating module and settings names in several places. This pull request reduces this complexity by moving all module related settings in a single place.

Another issue was with the way `ICM_ConfigWindow` and modules (`value: this.config.enabled`) kept their physical copies of config values. You can see a nasty bug stemming from that if you try to change a setting in the config window, hit Save and switch to another module and back; you'd still see an old value. I've fixed it by forcing everything to access cfg by reference, which also required changing OOP structure a bit (monk-time@2381ab4d764641591837b670e6b2c42d4146530e). As a side effect, outdated or renamed options do not clutter cfg anymore, and every module can use `ICM_Config.Set/Get/Save` if needed (see `updateConfig()`).

Finally, I moved the main code outside of `$(document).ready` check since Greasemonkey executes scripts at [DOMContentLoaded](http://wiki.greasespot.net/DOMContentLoaded) (monk-time@467340d602510d90bac3e8d9fd53bff0bf2e403d), and tried to replace all dangerous `eval/uneval` manupulations with `JSON.parse/stringify`, while keeping old settings when updating from an old version (monk-time@093f75794b6bf85d11627dfb44908a74a2d2cf61, monk-time@d13f8331a411704b4f58aac31409dbe7e747896f).

I have tested this versioin in Firefox and Chrome, but it would be great if you could take a look in your browser and confirm that it works all right. 
