### PR TITLE
Linting, style checking and a couple of bugfixes

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,34 @@
+{
+    "esnext": true,
+    "requireCurlyBraces": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "try",
+        "catch"
+    ],
+    "disallowKeywords": ["with"],
+    "requireSpaceAfterBinaryOperators": true,
+    "requireSpaceAfterKeywords": [
+        "if",
+        "else",
+        "for",
+        "while",
+        "do",
+        "switch",
+        "case",
+        "return",
+        "try",
+        "catch",
+        "typeof"
+    ],
+    "disallowSpaceAfterPrefixUnaryOperators": true,
+    "requireSpaceBeforeBinaryOperators": true,
+    "requireSpaceBetweenArguments": true,
+    "disallowTrailingWhitespace": true,
+    "validateIndentation": 4,
+    "validateLineBreaks": "LF",
+    "validateParameterSeparator": ", "
+}

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,5 +1,6 @@
 {
     "esnext": true,
+    "requireBlocksOnNewline": true,
     "requireCurlyBraces": [
         "if",
         "else",
@@ -13,6 +14,7 @@
     "requireCapitalizedConstructors": true,
     "requireCommaBeforeLineBreak": true,
     "requireDotNotation": true,
+    "disallowEmptyBlocks": true,
     "disallowKeywords": ["with"],
     "disallowKeywordsOnNewLine": [
         "else",
@@ -22,7 +24,10 @@
     "disallowMixedSpacesAndTabs": true,
     "disallowMultipleLineBreaks": true,
     "disallowMultipleLineStrings": true,
+    "disallowNewlineBeforeBlockStatements": true,
     "requireParenthesesAroundIIFE": true,
+    "disallowQuotedKeysInObjects": true,
+    "requireSemicolons": true,
     "requireSpaceAfterBinaryOperators": true,
     "requireSpaceAfterKeywords": [
         "if",
@@ -37,6 +42,7 @@
         "catch",
         "typeof"
     ],
+    "requireSpaceAfterLineComment": true,
     "disallowSpaceAfterObjectKeys": true,
     "disallowSpaceAfterPrefixUnaryOperators": true,
     "disallowSpaceBeforeBinaryOperators": [","],
@@ -44,7 +50,9 @@
     "requireSpaceBeforeBlockStatements": true,
     "disallowSpaceBeforePostfixUnaryOperators": true,
     "requireSpaceBeforeObjectValues": true,
+    "disallowSpaceBeforeSemicolon": true,
     "requireSpaceBetweenArguments": true,
+    "disallowSpacesInCallExpression": true,
     "requireSpacesInConditionalExpression": true,
     "requireSpacesInForStatement": true,
     "disallowSpacesInFunctionDeclaration": {
@@ -53,12 +61,20 @@
     "requireSpacesInFunctionDeclaration": {
         "beforeOpeningCurlyBrace": true
     },
+    "disallowSpacesInAnonymousFunctionExpression": {
+        "beforeOpeningRoundBrace": true
+    },
+    "requireSpacesInAnonymousFunctionExpression": {
+        "beforeOpeningCurlyBrace": true
+    },
     "disallowSpacesInNamedFunctionExpression": {
         "beforeOpeningRoundBrace": true
     },
     "requireSpacesInNamedFunctionExpression": {
         "beforeOpeningCurlyBrace": true
     },
+    "disallowSpacesInsideBrackets": true,
+    "requireSpacesInsideObjectBrackets": "all",
     "disallowSpacesInsideParentheses": true,
     "disallowTrailingWhitespace": true,
     "maximumLineLength": {

--- a/.jscsrc
+++ b/.jscsrc
@@ -42,6 +42,10 @@
     "requireSpacesInConditionalExpression": true,
     "requireSpacesInForStatement": true,
     "disallowTrailingWhitespace": true,
+    "maximumLineLength": {
+        "value": 100,
+        "allExcept": ["urlComments", "regex"]
+    },
     "validateIndentation": 4,
     "validateLineBreaks": "LF",
     "validateParameterSeparator": ", ",

--- a/.jscsrc
+++ b/.jscsrc
@@ -9,6 +9,7 @@
         "try",
         "catch"
     ],
+    "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties", // only for configs
     "requireDotNotation": true,
     "disallowKeywords": ["with"],
     "disallowKeywordsOnNewLine": [

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,10 +1,18 @@
 {
     // "preset": "airbnb",
-    // Settings that should be disabled when extending a preset
+
+    // --- Settings that don't fit this codebase
+    // --- and should be disabled when extending a preset
+    // "disallowAnonymousFunctions": null,
     // "disallowMultipleVarDecl": null,
     // "requirePaddingNewLinesBeforeLineComments": null,
-    // "requireTrailingComma": null,
+    // "requireAlignedObjectValues": null,
+    // "requireArrowFunctions": null,
     // "requireVarDeclFirst": null,
+
+    // --- Settings to revisit later
+    // "requireShorthandArrowFunctions": null,
+    // "requireTrailingComma": null,
 
     "esnext": true,
     "requireBlocksOnNewline": true,
@@ -20,6 +28,7 @@
     "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties", // only for configs
     "requireCapitalizedConstructors": true,
     "requireCommaBeforeLineBreak": true,
+    "requireDollarBeforejQueryAssignment": true,
     "requireDotNotation": true,
     "disallowEmptyBlocks": true,
     "disallowKeywords": ["with"],

--- a/.jscsrc
+++ b/.jscsrc
@@ -59,6 +59,7 @@
     "requireSpacesInNamedFunctionExpression": {
         "beforeOpeningCurlyBrace": true
     },
+    "disallowSpacesInsideParentheses": true,
     "disallowTrailingWhitespace": true,
     "maximumLineLength": {
         "value": 100,

--- a/.jscsrc
+++ b/.jscsrc
@@ -3,15 +3,20 @@
 
     // --- Settings that don't fit this codebase
     // --- and should be disabled when extending a preset
+    // "requireAlignedObjectValues": null,
     // "disallowAnonymousFunctions": null,
+    // "requireArrowFunctions": null,
+    // "requireFunctionDeclarations": null,
+    // "disallowMultipleSpaces": null,
     // "disallowMultipleVarDecl": null,
     // "requirePaddingNewLinesBeforeLineComments": null,
-    // "requireAlignedObjectValues": null,
-    // "requireArrowFunctions": null,
     // "requireVarDeclFirst": null,
+    // "validateNewlineAfterArrayElements": null,
 
     // --- Settings to revisit later
+    // "disallowParenthesesAroundArrowParam": null,
     // "requireShorthandArrowFunctions": null,
+    // "requireTemplateStrings": null,
     // "requireTrailingComma": null,
 
     "esnext": true,
@@ -38,10 +43,12 @@
     ],
     "requireLineBreakAfterVariableAssignment": true,
     "requireLineFeedAtFileEnd": true,
+    "requireMatchingFunctionName": true,
     "disallowMixedSpacesAndTabs": true,
     "disallowMultipleLineBreaks": true,
     "disallowMultipleLineStrings": true,
     "disallowNewlineBeforeBlockStatements": true,
+    "disallowNodeTypes": ["LabeledStatement"],
     "disallowOperatorBeforeLineBreak": ["."],
     "requireOperatorBeforeLineBreak": true,
     "requirePaddingNewLinesAfterBlocks": {
@@ -114,6 +121,7 @@
         "allExcept": ["urlComments", "regex"]
     },
     "safeContextKeyword": ["that"],
+    "validateAlignedFunctionParameters": true,
     "validateIndentation": 4,
     "validateLineBreaks": "LF",
     "validateParameterSeparator": ", ",

--- a/.jscsrc
+++ b/.jscsrc
@@ -30,5 +30,6 @@
     "disallowTrailingWhitespace": true,
     "validateIndentation": 4,
     "validateLineBreaks": "LF",
-    "validateParameterSeparator": ", "
+    "validateParameterSeparator": ", ",
+    "validateQuoteMarks": "'"
 }

--- a/.jscsrc
+++ b/.jscsrc
@@ -20,11 +20,14 @@
         "else",
         "catch"
     ],
+    "requireLineBreakAfterVariableAssignment": true,
     "requireLineFeedAtFileEnd": true,
     "disallowMixedSpacesAndTabs": true,
     "disallowMultipleLineBreaks": true,
     "disallowMultipleLineStrings": true,
     "disallowNewlineBeforeBlockStatements": true,
+    "disallowOperatorBeforeLineBreak": ["."],
+    "requireOperatorBeforeLineBreak": true,
     "requireParenthesesAroundIIFE": true,
     "disallowQuotedKeysInObjects": true,
     "requireSemicolons": true,
@@ -48,6 +51,7 @@
     "disallowSpaceBeforeBinaryOperators": [","],
     "requireSpaceBeforeBinaryOperators": true,
     "requireSpaceBeforeBlockStatements": true,
+    "disallowSpaceBeforeComma": true,
     "disallowSpaceBeforePostfixUnaryOperators": true,
     "requireSpaceBeforeObjectValues": true,
     "disallowSpaceBeforeSemicolon": true,
@@ -77,6 +81,7 @@
     "requireSpacesInsideObjectBrackets": "all",
     "disallowSpacesInsideParentheses": true,
     "disallowTrailingWhitespace": true,
+    "disallowYodaConditions": true,
     "maximumLineLength": {
         "value": 100,
         "allExcept": ["urlComments", "regex"]
@@ -84,5 +89,21 @@
     "validateIndentation": 4,
     "validateLineBreaks": "LF",
     "validateParameterSeparator": ", ",
-    "validateQuoteMarks": "'"
+    "validateQuoteMarks": "'",
+
+    "jsDoc": {
+        "checkAnnotations": "jsdoc3",
+        "checkParamNames": true,
+        "requireParamTypes": true,
+        "checkRedundantParams": true,
+        "checkReturnTypes": true,
+        "checkRedundantReturns": true,
+        "requireReturnTypes": true,
+        "checkTypes": "strictNativeCase",
+        "checkRedundantAccess": true,
+        "leadingUnderscoreAccess": true,
+        "requireHyphenBeforeDescription": true,
+        "requireNewlineAfterDescription": true,
+        "requireDescriptionCompleteSentence": true
+    }
 }

--- a/.jscsrc
+++ b/.jscsrc
@@ -10,6 +10,8 @@
         "catch"
     ],
     "requireCamelCaseOrUpperCaseIdentifiers": "ignoreProperties", // only for configs
+    "requireCapitalizedConstructors": true,
+    "requireCommaBeforeLineBreak": true,
     "requireDotNotation": true,
     "disallowKeywords": ["with"],
     "disallowKeywordsOnNewLine": [
@@ -18,6 +20,9 @@
     ],
     "requireLineFeedAtFileEnd": true,
     "disallowMixedSpacesAndTabs": true,
+    "disallowMultipleLineBreaks": true,
+    "disallowMultipleLineStrings": true,
+    "requireParenthesesAroundIIFE": true,
     "requireSpaceAfterBinaryOperators": true,
     "requireSpaceAfterKeywords": [
         "if",
@@ -38,9 +43,22 @@
     "requireSpaceBeforeBinaryOperators": true,
     "requireSpaceBeforeBlockStatements": true,
     "disallowSpaceBeforePostfixUnaryOperators": true,
+    "requireSpaceBeforeObjectValues": true,
     "requireSpaceBetweenArguments": true,
     "requireSpacesInConditionalExpression": true,
     "requireSpacesInForStatement": true,
+    "disallowSpacesInFunctionDeclaration": {
+        "beforeOpeningRoundBrace": true
+    },
+    "requireSpacesInFunctionDeclaration": {
+        "beforeOpeningCurlyBrace": true
+    },
+    "disallowSpacesInNamedFunctionExpression": {
+        "beforeOpeningRoundBrace": true
+    },
+    "requireSpacesInNamedFunctionExpression": {
+        "beforeOpeningCurlyBrace": true
+    },
     "disallowTrailingWhitespace": true,
     "maximumLineLength": {
         "value": 100,

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,4 +1,11 @@
 {
+    // "preset": "airbnb",
+    // Settings that should be disabled when extending a preset
+    // "disallowMultipleVarDecl": null,
+    // "requirePaddingNewLinesBeforeLineComments": null,
+    // "requireTrailingComma": null,
+    // "requireVarDeclFirst": null,
+
     "esnext": true,
     "requireBlocksOnNewline": true,
     "requireCurlyBraces": [
@@ -31,6 +38,7 @@
     "requirePaddingNewLinesAfterBlocks": {
         "allExcept": ["inCallExpressions"]
     },
+    "disallowPaddingNewlinesInBlocks": true,
     "requireParenthesesAroundIIFE": true,
     "disallowQuotedKeysInObjects": true,
     "requireSemicolons": true,
@@ -55,6 +63,12 @@
     "requireSpaceBeforeBinaryOperators": true,
     "requireSpaceBeforeBlockStatements": true,
     "disallowSpaceBeforeComma": true,
+    "requireSpaceBeforeKeywords": [
+        "else",
+        "while",
+        "catch",
+        "finally"
+    ],
     "disallowSpaceBeforePostfixUnaryOperators": true,
     "requireSpaceBeforeObjectValues": true,
     "disallowSpaceBeforeSemicolon": true,
@@ -85,10 +99,12 @@
     "disallowSpacesInsideParentheses": true,
     "disallowTrailingWhitespace": true,
     "disallowYodaConditions": true,
+
     "maximumLineLength": {
         "value": 100,
         "allExcept": ["urlComments", "regex"]
     },
+    "safeContextKeyword": ["that"],
     "validateIndentation": 4,
     "validateLineBreaks": "LF",
     "validateParameterSeparator": ", ",

--- a/.jscsrc
+++ b/.jscsrc
@@ -28,6 +28,9 @@
     "disallowNewlineBeforeBlockStatements": true,
     "disallowOperatorBeforeLineBreak": ["."],
     "requireOperatorBeforeLineBreak": true,
+    "requirePaddingNewLinesAfterBlocks": {
+        "allExcept": ["inCallExpressions"]
+    },
     "requireParenthesesAroundIIFE": true,
     "disallowQuotedKeysInObjects": true,
     "requireSemicolons": true,

--- a/.jscsrc
+++ b/.jscsrc
@@ -9,7 +9,14 @@
         "try",
         "catch"
     ],
+    "requireDotNotation": true,
     "disallowKeywords": ["with"],
+    "disallowKeywordsOnNewLine": [
+        "else",
+        "catch"
+    ],
+    "requireLineFeedAtFileEnd": true,
+    "disallowMixedSpacesAndTabs": true,
     "requireSpaceAfterBinaryOperators": true,
     "requireSpaceAfterKeywords": [
         "if",
@@ -24,9 +31,15 @@
         "catch",
         "typeof"
     ],
+    "disallowSpaceAfterObjectKeys": true,
     "disallowSpaceAfterPrefixUnaryOperators": true,
+    "disallowSpaceBeforeBinaryOperators": [","],
     "requireSpaceBeforeBinaryOperators": true,
+    "requireSpaceBeforeBlockStatements": true,
+    "disallowSpaceBeforePostfixUnaryOperators": true,
     "requireSpaceBetweenArguments": true,
+    "requireSpacesInConditionalExpression": true,
+    "requireSpacesInForStatement": true,
     "disallowTrailingWhitespace": true,
     "validateIndentation": 4,
     "validateLineBreaks": "LF",

--- a/.jshintrc
+++ b/.jshintrc
@@ -33,10 +33,11 @@
 
     // Custom Globals
     "globals"  : {      // true == r/w, false == read-only
-        "unsafeWindow": false,
-        "GM_setValue": false,
-        "GM_getValue": false,
-        "GM_addStyle": false,
+        "unsafeWindow"      : false,
+        "GM_info"           : false,
+        "GM_setValue"       : false,
+        "GM_getValue"       : false,
+        "GM_addStyle"       : false,
         "GM_getResourceText": false
     }
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -35,6 +35,7 @@
     "globals"  : {      // true == r/w, false == read-only
         "GM_setValue": false,
         "GM_getValue": false,
-        "GM_addStyle": false
+        "GM_addStyle": false,
+        "GM_getResourceText": false
     }
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,40 @@
+{
+    // Enforcing (set to true to produce more warnings)
+    "bitwise"     : true,  // Prohibit bitwise operators (&, |, ^, etc.)
+    "eqeqeq"      : true,  // Require triple equals (===) for comparison
+    "forin"       : true,  // Require filtering for..in loops with obj.hasOwnProperty()
+    "freeze"      : true,  // Prohibit overwriting prototypes of native objects
+    "noarg"       : true,  // Prohibit use of `arguments.caller` and `arguments.callee`
+    "nocomma"     : true,  // Prohibit use of a comma operator
+    "nonbsp"      : true,  // Prohibit "non-breaking whitespace" characters
+    "nonew"       : true,  // Prohibit use of constructors for side-effects (without assignment)
+    "singleGroups": true,  // Prohibit unnecessary grouping operators
+    "undef"       : true,  // Require all non-global variables to be declared
+    "unused"      : true,  // Warn about unused variables:
+                           //   true     : all variables, last function parameter
+                           //   "vars"   : all variables only
+                           //   "strict" : all variables, all function parameters
+
+    // Enforcing - deprecated (should be removed after v3.*)
+    "camelcase"   : false, // Identifiers must be in camelCase
+                           // TODO: temporary disabled until fixed
+    "immed"       : true,  // Require immediate invocations to be wrapped in parens
+    "newcap"      : false, // Require capitalization of all constructor functions
+                           // NOTE: for GM_ APIs (their names break this convention)
+    "noempty"     : true,  // Prohibit use of empty blocks
+
+    // Relaxing (set to true to produce fewer warnings)
+    "esnext"      : true,  // Allow ES.next (ES6) syntax (ex: `const`)
+
+    // Environments
+    "browser"     : true,  // Web Browser (window, document, etc)
+    "devel"       : true,  // Development/debugging (alert, console, etc)
+    "jquery"      : true,  // jQuery
+
+    // Custom Globals
+    "globals"  : {      // true == r/w, false == read-only
+        "GM_setValue": false,
+        "GM_getValue": false,
+        "GM_addStyle": false
+    }
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -33,6 +33,7 @@
 
     // Custom Globals
     "globals"  : {      // true == r/w, false == read-only
+        "unsafeWindow": false,
         "GM_setValue": false,
         "GM_getValue": false,
         "GM_addStyle": false,

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -303,7 +303,7 @@ ConfigWindow.prototype.build = function() {
         top: '17%', left: '50%', marginLeft: '-400px', width: '800px', height: '450px'
     }).appendTo('body');
 
-    var _t = this;
+    var that = this;
 
     $('div#cfgModal').on('change', 'input, textarea', function() {
         var index = $(this).data('cfg-index');
@@ -311,22 +311,22 @@ ConfigWindow.prototype.build = function() {
             return;
         }
 
-        if (!_t.config.toggle(index)) {
-            _t.config.set(index, $(this).val());
+        if (!that.config.toggle(index)) {
+            that.config.set(index, $(this).val());
         }
 
         $('button#configSave').prop('disabled', false);
     });
 
     $('div#cfgModal').on('click', 'button#configSave', function() {
-        _t.config.save();
+        that.config.save();
 
         $(this).prop('disabled', true);
     });
 
     $('#modulelist').on('change', function() {
         var idx = document.getElementById('modulelist').selectedIndex;
-        _t.loadOptions(idx);
+        that.loadOptions(idx);
     });
 
     $('#modulelist').trigger('change');
@@ -703,7 +703,7 @@ UpcomingAwardsOverview.prototype.htmlOut = function() {
     // hide hidden
     $lists.filter('.hidden-list').hide();
 
-    var _this = this;
+    var that = this;
 
     $('a.icm_toggle_list').on('click', function(e) {
         e.preventDefault();
@@ -711,13 +711,13 @@ UpcomingAwardsOverview.prototype.htmlOut = function() {
         var $parent = $(this).parent().parent(),
             listTitle = $.trim($parent.find('.list-title').text()),
             listUrl = $parent.data('list-url'),
-            ind = _this.hiddenLists.indexOf(listUrl),
+            ind = that.hiddenLists.indexOf(listUrl),
             hide = ind === -1;
 
         if (hide) { // hide list
-            _this.hiddenLists.push(listUrl);
+            that.hiddenLists.push(listUrl);
         } else { // unhide list
-            _this.hiddenLists.splice(ind, 1);
+            that.hiddenLists.splice(ind, 1);
         }
 
         $lists.filter(hide ? 'tr' : 'tr.hidden-list')
@@ -729,7 +729,7 @@ UpcomingAwardsOverview.prototype.htmlOut = function() {
             .find('.icm_toggle_list > img').replaceWith(getIcon(!hide, listTitle));
 
         // save hidden lists
-        gmSetValue('hidden_lists', JSON.stringify(_this.hiddenLists));
+        gmSetValue('hidden_lists', JSON.stringify(that.hiddenLists));
     });
 
     $('#toggle_hidden_list').on('click', function(e) {
@@ -902,12 +902,12 @@ ListCrossCheck.prototype.attach = function() {
         '<button id="cfgListCCActivate">Activate CR</button></div>';
 
     $('#itemContainer').before(actions);
-    var _t = this;
+    var that = this;
 
     $('div#crActions').on('click', 'button#cfgListCCActivate', function() {
         $(this).prop('disabled', true);
-        _t.createTab();
-        _t.activate();
+        that.createTab();
+        that.activate();
     });
 
     var customCSS = '<style type="text/css">' +
@@ -925,13 +925,13 @@ ListCrossCheck.prototype.attach = function() {
 ListCrossCheck.prototype.activate = function() {
     this.init();
     this.activated = true;
-    var _t = this;
+    var that = this;
 
     $('button#cfgListCCActivate')
         .after('<button id="cfgListCCDeactivate">Deactivate</button>');
 
     $('div#crActions').on('click', 'button#cfgListCCDeactivate', function() {
-        _t.deactivate();
+        that.deactivate();
         $('button#cfgListCCActivate').prop('disabled', false);
     });
 
@@ -941,7 +941,7 @@ ListCrossCheck.prototype.activate = function() {
     }
 
     $('ol#itemListToplists li').on('click mouseover mouseout', function(e) {
-        var activeAndIdle = _t.activated && !_t.inProgress;
+        var activeAndIdle = that.activated && !that.inProgress;
         if (!activeAndIdle) { // ff 3.6 compatibility
             return;
         }
@@ -1031,17 +1031,17 @@ ListCrossCheck.prototype.getUncheckedFilms = function(listElem) {
 
     $(listElem).addClass('icme_listcc_pending');
 
-    var _t = this;
+    var that = this;
 
     $.get(url, function(response) {
         $(listElem).removeClass('icme_listcc_selected icme_listcc_pending')
             .find('span.percentage').show();
 
-        var filter = _t.config.checks ? '' : 'li.unchecked';
+        var filter = that.config.checks ? '' : 'li.unchecked';
         // the site returns html with extra whitespace
         var unchecked = $($.parseHTML(response)).find('ol#itemListMovies').children(filter);
 
-        _t.updateMovies(unchecked);
+        that.updateMovies(unchecked);
     });
 };
 
@@ -1251,7 +1251,7 @@ ListCrossCheck.prototype.createTab = function() {
     var $tlfilter = $('ul.tabMenu', 'div#itemContainer');
     $tlfilter.append(tab);
 
-    var _t = this;
+    var that = this;
 
     // Modified from ICM source. Make the tab work.
     $('#listFilterCRSelected a').on('click', function() {
@@ -1262,7 +1262,7 @@ ListCrossCheck.prototype.createTab = function() {
         });
         b.addClass('active');
 
-        if (a === 'icme_listcc' && !_t.inProgress) {
+        if (a === 'icme_listcc' && !that.inProgress) {
             var $topListUl = $('ol#itemListToplists');
             $topListUl.children('li.icme_listcc').remove();
 
@@ -1283,7 +1283,7 @@ ListCrossCheck.prototype.createTab = function() {
                 $('button#icme_listcc_check').on('click', function() {
                     $(this).prop('disabled', true);
 
-                    _t.check();
+                    that.check();
                 });
 
                 // Make the current tab work if we want to return to it
@@ -1601,11 +1601,11 @@ LargeList.prototype.attach = function() {
         }
     }
 
-    var _t = this;
+    var that = this;
     $('#icme_large_posters').on('click', function(e) {
         e.preventDefault();
 
-        _t.load();
+        that.load();
     });
 };
 
@@ -1710,10 +1710,10 @@ ListOverviewSort.prototype.attach = function() {
     var order = this.config.order === true ? 'desc' : 'asc';
     this.rearrange(order, 'all');
 
-    var _t = this;
+    var that = this;
     $('#progressFilter a').not('#progressFilter-all').one('click', function() {
         var section = $(this).attr('id').split('-')[1];
-        _t.rearrange(order, section);
+        that.rearrange(order, section);
     });
 };
 
@@ -1877,19 +1877,19 @@ ListsTabDisplay.prototype.attach = function() {
         }
 
         if (_c.sort_groups) {
-            var _t = this;
+            var that = this;
             ['group1', 'group2'].forEach(function(group) {
                 var stored = _c[group];
                 if (typeof stored === 'string') {
                     // Parse textarea content
                     console.log('Parsing ListsTabDisplay group', group);
-                    stored = stored.trim().replace(_t.reURL, '$1').split('\n');
+                    stored = stored.trim().replace(that.reURL, '$1').split('\n');
                     _c[group] = stored;
-                    _t.globalConfig.save();
+                    that.globalConfig.save();
                 }
 
-                var personal = _t.getLists(stored);
-                _t.move(personal);
+                var personal = that.getLists(stored);
+                that.move(personal);
             });
         }
 

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -2,7 +2,7 @@
 // @name           iCheckMovies Enhanced
 // @namespace      iCheckMovies
 // @description    Adds new features to enhance the iCheckMovies user experience
-// @version        1.7.6.2
+// @version        1.7.7
 // @include        http://icheckmovies.com*
 // @include        http://www.icheckmovies.com*
 // @include        https://icheckmovies.com*
@@ -19,7 +19,8 @@
 // ==/UserScript==
 
 // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
-var gmSetValue = GM_setValue,
+var gmInfo = GM_info,
+    gmSetValue = GM_setValue,
     gmGetValue = GM_getValue,
     gmAddStyle = GM_addStyle,
     gmGetResourceText = GM_getResourceText;
@@ -116,10 +117,17 @@ BaseFeature.prototype.updateConfig = function(config) {
 
 // Config object constructor
 function Config() {
+    // test:
+    // ['1', '1.7', '1.7.1', '1.7.1.1', '1.7.1.1.1'].map(verToNumber) ===
+    // [1000, 1700, 1710, 1711, 1711]
+    function verToNumber(str) {
+        return +(str.replace(/\./g, '') + '0000').slice(0, 4);
+    }
+
     this.cfg = {
         script_config: { // script config
-            version: '1.7.6.2',
-            revision: 1762 // numerical representation of version number
+            version: gmInfo.script.version, // dot-separated string
+            revision: verToNumber(gmInfo.script.version) // 4-digit number
         }
     };
 
@@ -141,6 +149,7 @@ Config.prototype.init = function() {
     this.cfg = oldcfg;
 
     if (isUpdated) {
+        console.log('Updating to ' + n.revision);
         this.save();
     }
 };

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -21,6 +21,7 @@
 //+ Jonas Raoni Soares Silva
 //@ http://jsfromhell.com/array/shuffle [rev. #1]
 var shuffle = function(v) {
+    /* jshint nocomma: false */
     for (var j, x, i = v.length;
         i > 1;
         j = Math.floor(Math.random() * i), x = v[--i], v[i] = v[j], v[j] = x);
@@ -40,7 +41,8 @@ function setProperty(path, obj, val) {
         last = parts.pop(),
         part;
 
-    while ((part = parts.shift())) { // assignment
+    /* jshint boss: true */
+    while (part = parts.shift()) { // assignment
         // rewrite property if it exists but is not an object
         obj = obj[part] = obj[part] instanceof Object ?
                           obj[part] : {};

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -221,7 +221,7 @@ ICM_ConfigWindow.prototype.loadOptions = function(idx) {
 };
 
 ICM_ConfigWindow.prototype.initColorPickers = function() {
-    $('.colorpicker').each(function(){
+    $('.colorpicker').each(function() {
         var $t = $(this);
         $t.spectrum({
             color: $t.prev().val(),
@@ -1533,7 +1533,7 @@ ICM_LargeList.prototype.load = function() {
         $c[i].parentNode.appendChild(img);
     }
 
-    $('img.coverImage').lazyload({ threshold : 200 });
+    $('img.coverImage').lazyload({ threshold: 200 });
 };
 
 ICM_LargeList.prototype.settings = {

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -34,6 +34,7 @@ var shuffle = function(v) {
         i > 1;
         j = Math.floor(Math.random() * i), x = v[--i], v[i] = v[j], v[j] = x) {
     }
+
     return v;
     // jscs:enable disallowEmptyBlocks
 };
@@ -172,6 +173,7 @@ Config.prototype.toggle = function(index) {
     } else {
         return false; // Couldn't toggle a value
     }
+
     this.set(index, changeVal);
     return true; // Value toggled
 };
@@ -211,6 +213,7 @@ ConfigWindow.prototype.loadOptions = function(idx) {
             if ($.isArray(optValue)) {
                 optValue = optValue.join('\n');
             }
+
             str += '<p><span style="vertical-align: top; margin-right: 5px">' + opt.desc +
                    ':</span><textarea rows="4" cols="70"' + indexAttr +
                    '>' + optValue + '</textarea></p>';
@@ -282,6 +285,7 @@ ConfigWindow.prototype.build = function() {
         var m = this.modules[i];
         moduleList += '<option value="' + i + '">' + m.title + '</option>';
     }
+
     moduleList += '</select>';
 
     // HTML for the main jqmodal window
@@ -365,10 +369,8 @@ RandomFilmLink.prototype.attach = function() {
     }
 
     var that = this;
-
     $('div#list_container').on('click', 'a#randomFilm', function(e) {
         e.preventDefault();
-
         that.pickRandomFilm();
     });
 };
@@ -446,6 +448,7 @@ UpcomingAwardsList.prototype.attach = function() {
         if (!abs && num <= 0) {
             return '';
         }
+
         return '<span style="margin-left: 30px">' + award + ': <b>' + num + '</b></span>';
     };
 
@@ -497,6 +500,7 @@ UpcomingAwardsOverview.prototype.attach = function() {
     if (!this.config.enabled) {
         return;
     }
+
     if (this.config.autoload) {
         this.loadAwardData();
         return;
@@ -582,6 +586,7 @@ UpcomingAwardsOverview.prototype.sortLists = function() {
         } else if (a.listTitle > b.listTitle) {
             return 1;
         }
+
         return 0;
     });
 };
@@ -811,6 +816,7 @@ ListCustomColors.prototype.attach = function() {
             if (!color.length) {
                 return;
             }
+
             var sel = 'ol#itemListMovies li.' + className;
             listColorsCss += sel + ', ' + sel + ' ul.optionIconMenu ' +
                 '{ background-color: ' + color + ' !important; }';
@@ -1003,6 +1009,7 @@ ListCrossCheck.prototype.check = function() {
         var checks = $(x).find('span.info > strong:first').text().split('/');
         return checks[1] - checks[0];
     };
+
     $toplists.sort(function(a, b) {
         return getUnchecked(a) < getUnchecked(b) ? -1 : 1;
     });
@@ -1157,6 +1164,7 @@ ListCrossCheck.prototype.outputMovies = function() {
         } else if (a.t > b.t) {
             return 1;
         }
+
         return 0;
     });
 
@@ -1493,6 +1501,7 @@ Owned.prototype.attach = function() {
             } else {
                 owned.push(movieId);
             }
+
             $movie.toggleClass('notowned owned');
 
             if (onListPage) {
@@ -1647,6 +1656,7 @@ LargeList.prototype.load = function() {
         } else { // chrome handles urls differently
             cururl = cururl.slice(4, -1).replace('small', 'medium').replace('Small', 'Medium');
         }
+
         var img = document.createElement('img');
         img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIA' +
             'AACQd1PeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMA' +
@@ -1749,10 +1759,12 @@ ListOverviewSort.prototype.rearrange = function(order, section) {
         // restore default two-column view after sorting/hiding
         toplistArr = this.interweave(toplistArr);
     }
+
     if (isInterweaved && verticalOrder) {
         // no sorting/hiding happened; rearrange the list with original order
         toplistArr = this.straighten(toplistArr);
     }
+
     $toplistList.append(toplistArr);
 };
 
@@ -1768,6 +1780,7 @@ ListOverviewSort.prototype.straighten = function(list) {
             odd.push(list[i]);
         }
     }
+
     return $.merge(even, odd);
 };
 
@@ -1782,6 +1795,7 @@ ListOverviewSort.prototype.interweave = function(list) {
             res.push(list[i + halfLen]);
         }
     }
+
     return res;
 };
 
@@ -1873,6 +1887,7 @@ ListsTabDisplay.prototype.attach = function() {
                     _c[group] = stored;
                     _t.globalConfig.save();
                 }
+
                 var personal = _t.getLists(stored);
                 _t.move(personal);
             });
@@ -1899,25 +1914,28 @@ ListsTabDisplay.prototype.attach = function() {
 };
 
 ListsTabDisplay.prototype.move = function(lists) {
-    if (lists.length) {
-        var target = this.block.find('li.groupSeparator').last();
-        if (target.length) {
-            target.after(lists, this.sep);
-        } else {
-            this.block.prepend(lists, this.sep);
-        }
+    if (!lists.length) {
+        return;
+    }
+
+    var target = this.block.find('li.groupSeparator').last();
+    if (target.length) {
+        target.after(lists, this.sep);
+    } else {
+        this.block.prepend(lists, this.sep);
     }
 };
 
 ListsTabDisplay.prototype.getLists = function(listIDs) {
-    if (listIDs.length) {
-        var selected = this.block.children().filter(function() {
-            var href = $(this).find('a.title').attr('href');
-            return href && $.inArray(href.substring(7), listIDs) !== -1; // sep matches too
-        });
-        return selected;
+    if (!listIDs.length) {
+        return [];
     }
-    return [];
+
+    var selected = this.block.children().filter(function() {
+        var href = $(this).find('a.title').attr('href');
+        return href && $.inArray(href.substring(7), listIDs) !== -1; // sep matches too
+    });
+    return selected;
 };
 
 ListsTabDisplay.prototype.settings = {

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -21,7 +21,9 @@
 //+ Jonas Raoni Soares Silva
 //@ http://jsfromhell.com/array/shuffle [rev. #1]
 var shuffle = function(v) {
-    for (var j, x, i = v.length; i; j = parseInt(Math.random() * i), x = v[--i], v[i] = v[j], v[j] = x);
+    for (var j, x, i = v.length;
+        i > 1;
+        j = Math.floor(Math.random() * i), x = v[--i], v[i] = v[j], v[j] = x);
     return v;
 };
 
@@ -358,8 +360,8 @@ ICM_RandomFilmLink.prototype.PickRandomFilm = function() {
                     this.random_nums.push( i );
                 }
 
-                // Shuffle the results for randomness
-                this.random_nums = shuffle( this.random_nums );
+                // Shuffle the results for randomness in-place
+                shuffle( this.random_nums );
             }
 
             rand_num = this.random_nums.pop();

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -9,7 +9,7 @@
 // @include        https://www.icheckmovies.com*
 // @require        http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js
 // @require        https://cdnjs.cloudflare.com/ajax/libs/jquery_lazyload/1.9.5/jquery.lazyload.min.js
-// @require        https://greasyfork.org/scripts/3595-jqmodal/code/jqModal.js?version=10865
+// @require        https://cdnjs.cloudflare.com/ajax/libs/jqModal/1.3.0/jqModal.min.js
 // @require        https://cdnjs.cloudflare.com/ajax/libs/spectrum/1.7.1/spectrum.min.js
 // @resource       spectrumCss https://cdnjs.cloudflare.com/ajax/libs/spectrum/1.7.1/spectrum.min.css
 // @grant          GM_setValue

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -27,7 +27,7 @@ var gmSetValue = GM_setValue,
 
 // + Jonas Raoni Soares Silva
 // @ http://jsfromhell.com/array/shuffle [rev. #1]
-var shuffle = function(v) {
+function shuffle(v) {
     /* jshint nocomma: false, noempty: false */
     // jscs:disable disallowEmptyBlocks
     for (var j, x, i = v.length;
@@ -37,7 +37,7 @@ var shuffle = function(v) {
 
     return v;
     // jscs:enable disallowEmptyBlocks
-};
+}
 
 // Get object property by a dot-separated path
 function getProperty(path, obj) {
@@ -644,7 +644,7 @@ UpcomingAwardsOverview.prototype.htmlOut = function() {
         var isHidden = this.hiddenLists.indexOf(el.listUrl) !== -1,
             icon = getIcon(!isHidden, el.listTitle);
 
-        listTable  += '<tr class="' + (isHidden ? 'hidden-list' : '') +
+        listTable += '<tr class="' + (isHidden ? 'hidden-list' : '') +
             '" data-award-type="' + el.awardType + '" data-list-url="' + el.listUrl + '">' +
             '<td style="width: 65px">' + el.awardType + '</td>' +
             '<td style="width: 65px">' + el.awardChecks + '</td>' +
@@ -809,25 +809,26 @@ function ListCustomColors(config) {
 }
 
 ListCustomColors.prototype.attach = function() {
-    if (this.config.enabled) {
-        var listColorsCss = '';
-
-        var buildCSS = function(className, color) {
-            if (!color.length) {
-                return;
-            }
-
-            var sel = 'ol#itemListMovies li.' + className;
-            listColorsCss += sel + ', ' + sel + ' ul.optionIconMenu ' +
-                '{ background-color: ' + color + ' !important; }';
-        };
-
-        buildCSS('favorite', this.config.colors.favorite);
-        buildCSS('watch', this.config.colors.watchlist);
-        buildCSS('hated', this.config.colors.disliked);
-
-        gmAddStyle(listColorsCss);
+    if (!this.config.enabled) {
+        return;
     }
+
+    function buildCSS(className, color) {
+        if (!color.length) {
+            return;
+        }
+
+        var sel = 'ol#itemListMovies li.' + className;
+        return sel + ', ' + sel + ' ul.optionIconMenu ' +
+            '{ background-color: ' + color + ' !important; }';
+    }
+
+    var listColorsCss =
+        buildCSS('favorite', this.config.colors.favorite) +
+        buildCSS('watch',    this.config.colors.watchlist) +
+        buildCSS('hated',    this.config.colors.disliked);
+
+    gmAddStyle(listColorsCss);
 };
 
 ListCustomColors.prototype.settings = {
@@ -1005,10 +1006,10 @@ ListCrossCheck.prototype.check = function() {
     this.inProgress = true;
 
     // sort selected top lists in ascending order by number of unchecked films
-    var getUnchecked = function(x) {
+    function getUnchecked(x) {
         var checks = $(x).find('span.info > strong:first').text().split('/');
         return checks[1] - checks[0];
-    };
+    }
 
     $toplists.sort(function(a, b) {
         return getUnchecked(a) < getUnchecked(b) ? -1 : 1;
@@ -2008,14 +2009,14 @@ ExportLists.prototype.attach = function() {
             sep = '\t';
         }
 
-        var data =  ['rank', 'title', 'aka', 'year', 'official_toplists',
+        var data = ['rank', 'title', 'aka', 'year', 'official_toplists',
             'checked', 'favorite', 'dislike', 'imdb'].join(sep) + sep + '\n';
 
-        var encodeField = function(field) {
+        function encodeField(field) {
             return field.indexOf('"') !== -1 || field.indexOf(sep) !== -1 ?
                    '"' + field.replace('"', '""', 'g') + '"' :
                    field;
-        };
+        }
 
         $('#itemListMovies > li').each(function() {
             var $item = $(this),

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -473,25 +473,25 @@ function UpcomingAwardsOverview(config) {
 }
 
 UpcomingAwardsOverview.prototype.attach = function() {
-    if ( this.config.enabled ) {
-        if ( this.config.autoload ) {
-            this.loadAwardData();
-        } else {
-            var loadLink = '<p id="lad_container"><a id="load_award_data" href="#">Load upcoming awards for this user</a></p>';
-
-            $('#listOrdering').before(loadLink);
-
-            var that = this;
-
-            $('p#lad_container').on('click', 'a#load_award_data', function(e) {
-                e.preventDefault();
-
-                $( e.target ).remove();
-
-                that.loadAwardData();
-            });
-        }
+    if ( !this.config.enabled ) {
+        return;
     }
+    if ( this.config.autoload ) {
+        this.loadAwardData();
+        return;
+    }
+
+    var loadLink = $('<p>', {id: 'lad_container'})
+        .append($('<a>', {id: 'load_award_data', href: '#', text: 'Load upcoming awards for this user'}));
+
+    $('#listOrdering').before(loadLink);
+
+    var that = this;
+    $('p#lad_container').on('click', 'a#load_award_data', function(e) {
+        e.preventDefault();
+        $( e.target ).remove();
+        that.loadAwardData();
+    });
 };
 
 UpcomingAwardsOverview.prototype.loadAwardData = function() {
@@ -565,40 +565,99 @@ UpcomingAwardsOverview.prototype.sortLists = function() {
     });
 };
 
+/**
+ * Create a function that generates <img> for a hide/unhide button.
+ * Using a factory allows to do costly line concat only once
+ * and only if this module is attached.
+ */
+UpcomingAwardsOverview.prototype.getIconFactory = function() {
+    var unhideIconData = 'data:text/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAA' +
+        'AQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW' +
+        '1hZ2VSZWFkeXHJZTwAAAGrSURBVDjLvZPZLkNhFIV75zjvYm7VGFNCqoZUJ+roKUUpjR' +
+        'uqp61Wq0NKDMelGGqOxBSUIBKXWtWGZxAvobr8lWjChRgSF//dv9be+9trCwAI/vIE/2' +
+        '6gXmviW5bqnb8yUK028qZjPfoPWEj4Ku5HBspgAz941IXZeze8N1bottSo8BTZviVWrE' +
+        'h546EO03EXpuJOdG63otJbjBKHkEp/Ml6yNYYzpuezWL4s5VMtT8acCMQcb5XL3eJE8V' +
+        'gBlR7BeMGW9Z4yT9y1CeyucuhdTGDxfftaBO7G4L+zg91UocxVmCiy51NpiP3n2treUP' +
+        'ujL8xhOjYOzZYsQWANyRYlU4Y9Br6oHd5bDh0bCpSOixJiWx71YY09J5pM/WEbzFcDmH' +
+        'vwwBu2wnikg+lEj4mwBe5bC5h1OUqcwpdC60dxegRmR06TyjCF9G9z+qM2uCJmuMJmaN' +
+        'ZaUrCSIi6X+jJIBBYtW5Cge7cd7sgoHDfDaAvKQGAlRZYc6ltJlMxX03UzlaRlBdQrzS' +
+        'CwksLRbOpHUSb7pcsnxCCwngvM2Rm/ugUCi84fycr4l2t8Bb6iqTxSCgNIAAAAAElFTk' +
+        'SuQmCC',
+        hideIconData = 'data:text/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAK' +
+        'CAYAAACNMs+9AAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1h' +
+        'Z2VSZWFkeXHJZTwAAADtSURBVHjajFC7DkFREJy9iXg0t+EHRKJDJSqRuIVaJT7AF+jR' +
+        '+xuNRiJyS8WlRaHWeOU+kBy7eyKhs8lkJrOzZ3OWzMAD15gxYhB+yzAm0ndez+eYMYLn' +
+        'gdkIf2vpSYbCfsNkOx07n8kgWa1UpptNII5VR/M56Nyt6Qq33bbhQsHy6aR0WSyEyEmi' +
+        'CG6vR2ffB65X4HCwYC2e9CTjJGGok4/7Hcjl+ImLBWv1uCRDu3peV5eGQ2C5/P1zq4X9' +
+        'dGpXP+LYhmYz4HbDMQgUosWTnmQoKKf0htVKBZvtFsx6S9bm48ktaV3EXwd/CzAAVjt+' +
+        'gHT5me0AAAAASUVORK5CYII=';
+
+    /**
+     * Generate <img> for a hide/unhide button
+     * @param {boolean} hide - true to hide, false to unhide
+     * @param {string} listTitle
+     */
+    var getIcon = function(hide, listTitle) {
+        return '<img src="' + (hide ? hideIconData : unhideIconData) + '" ' +
+            'alt="' + (hide ? 'Hide ' : 'Unhide ') + 'icon" ' +
+            'title="' + (hide ? 'Hide ' : 'Unhide ') + listTitle + '">';
+    };
+
+    return getIcon;
+};
+
 UpcomingAwardsOverview.prototype.htmlOut = function() {
-    var unhideIconData = 'data:text/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAGrSURBVDjLvZPZLkNhFIV75zjvYm7VGFNCqoZUJ+roKUUpjRuqp61Wq0NKDMelGGqOxBSUIBKXWtWGZxAvobr8lWjChRgSF//dv9be+9trCwAI/vIE/26gXmviW5bqnb8yUK028qZjPfoPWEj4Ku5HBspgAz941IXZeze8N1bottSo8BTZviVWrEh546EO03EXpuJOdG63otJbjBKHkEp/Ml6yNYYzpuezWL4s5VMtT8acCMQcb5XL3eJE8VgBlR7BeMGW9Z4yT9y1CeyucuhdTGDxfftaBO7G4L+zg91UocxVmCiy51NpiP3n2treUPujL8xhOjYOzZYsQWANyRYlU4Y9Br6oHd5bDh0bCpSOixJiWx71YY09J5pM/WEbzFcDmHvwwBu2wnikg+lEj4mwBe5bC5h1OUqcwpdC60dxegRmR06TyjCF9G9z+qM2uCJmuMJmaNZaUrCSIi6X+jJIBBYtW5Cge7cd7sgoHDfDaAvKQGAlRZYc6ltJlMxX03UzlaRlBdQrzSCwksLRbOpHUSb7pcsnxCCwngvM2Rm/ugUCi84fycr4l2t8Bb6iqTxSCgNIAAAAAElFTkSuQmCC';
-    var hideIconData = 'data:text/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADtSURBVHjajFC7DkFREJy9iXg0t+EHRKJDJSqRuIVaJT7AF+jR+xuNRiJyS8WlRaHWeOU+kBy7eyKhs8lkJrOzZ3OWzMAD15gxYhB+yzAm0ndez+eYMYLngdkIf2vpSYbCfsNkOx07n8kgWa1UpptNII5VR/M56Nyt6Qq33bbhQsHy6aR0WSyEyEmiCG6vR2ffB65X4HCwYC2e9CTjJGGok4/7Hcjl+ImLBWv1uCRDu3peV5eGQ2C5/P1zq4X9dGpXP+LYhmYz4HbDMQgUosWTnmQoKKf0htVKBZvtFsx6S9bm48ktaV3EXwd/CzAAVjt+gHT5me0AAAAASUVORK5CYII=';
+    var getIcon = this.getIconFactory(),
+        listTable =
+            '<table id="award_table"><thead><tr id="award_table_head">' +
+                '<th>Awards</th><th>Checks</th><th>List title</th><th>(Un)Hide</th>' +
+            '</tr></thead><tbody>';
 
-    var listTable = '<table id="award_table"><thead><tr id="award_table_head"><th>Awards</th><th>Checks</th><th>List title</th><th>(Un)Hide</th></tr></head><tbody>';
-
-    for ( var i = 0; i < this.lists.length; i++ ) {
-        var el = this.lists[i],
-            unhideIcon = '<img title="Unhide ' + el.listTitle + '" alt="Unhide icon" src="' + unhideIconData + '">',
-            hideIcon = '<img title="Hide ' + el.listTitle + '" alt="Hide icon" src="' + hideIconData + '">',
-            isHidden = this.hiddenLists.indexOf(el.listUrl) !== -1;
+    for (var el of this.lists) {
+        var isHidden = this.hiddenLists.indexOf(el.listUrl) !== -1,
+            icon = getIcon(!isHidden, el.listTitle);
 
         listTable  += '<tr class="' + (isHidden ? 'hidden-list' : '') +
             '" data-award-type="' + el.awardType + '" data-list-url="' + el.listUrl + '">' +
             '<td style="width: 65px">' + el.awardType + '</td>' +
             '<td style="width: 65px">' + el.awardChecks + '</td>' +
-            '<td><div style="height: 28px; overflow: hidden"><a class="list-title" href="' + el.listUrl + '">' + el.listTitle + '</a></div></td>' +
-            '<td style="width: 70px"><a href="#" class="icm_hide_list">' + (isHidden ? unhideIcon : hideIcon) + '</a></td></tr>';
+            '<td><div style="height: 28px; overflow: hidden">' +
+                '<a class="list-title" href="' + el.listUrl + '">' + el.listTitle + '</a></div></td>' +
+            '<td style="width: 70px"><a href="#" class="icm_toggle_list">' + icon + '</a></td></tr>';
     }
 
     listTable += '</tbody></table>';
 
     // build the html...
-    var toggleUpcomingLink = '<p id="ua_toggle_link_container" style="position: relative; left:0; top:0; width: 200px"><a id="toggle_upcoming_awards" href="#"><span class="_show" style="display: none">Show upcoming awards</span><span class="_hide">Hide upcoming awards</span></a></p>';
-    var toggleFullLink     = '<a id="toggle_full_list" href="#"><span class="_show">Show full list</span><span class="_hide" style="display: none">Minimize full list</span></a>';
-    var toggleHiddenLink   = '<a id="toggle_hidden_list" href="#">Show hidden</a>';
+    var toggleUpcomingLink =
+        '<p id="ua_toggle_link_container" style="position: relative; left:0; top:0; width: 200px">' +
+            '<a id="toggle_upcoming_awards" href="#">' +
+                '<span class="_show" style="display: none">Show upcoming awards</span>' +
+                '<span class="_hide">Hide upcoming awards</span></a></p>';
+    var toggleFullLink =
+        '<a id="toggle_full_list" href="#">' +
+            '<span class="_show">Show full list</span>' +
+            '<span class="_hide" style="display: none">Minimize full list</span></a>';
+    var toggleHiddenLink = '<a id="toggle_hidden_list" href="#">Show hidden</a>';
 
-    var links = '<p id="award_display_links" style="position: absolute; right: 0; top: 0; font-weight: bold">Display: <a id="display_all" href="#">All</a>, ' +
-        '<a id="display_bronze" href="#">Bronze</a>, <a id="display_silver" href="#">Silver</a>, <a id="display_gold" href="#">Gold</a>, ' +
-        '<a id="display_platinum" href="#">Platinum</a>, ' + toggleFullLink + ', ' + toggleHiddenLink + '</p>';
+    var links =
+        '<p id="award_display_links" style="position: absolute; right: 0; top: 0; font-weight: bold">' +
+            'Display: <a id="display_all" href="#">All</a>, ' +
+            '<a id="display_bronze" href="#">Bronze</a>, ' +
+            '<a id="display_silver" href="#">Silver</a>, ' +
+            '<a id="display_gold" href="#">Gold</a>, ' +
+            '<a id="display_platinum" href="#">Platinum</a>, ' +
+            toggleFullLink + ', ' + toggleHiddenLink + '</p>';
 
-    var awardContainer = '<div id="award_container" class="container" style="position: relative; top: 0; width: 830px; height: 240px; overflow: scroll">' + listTable + '</div>';
+    var awardContainer =
+        '<div id="award_container" class="container" ' +
+        'style="position: relative; top: 0; width: 830px; height: 240px; overflow: scroll">' +
+            listTable + '</div>';
 
-    var allHtml = '<div id="icm_award_html_container" style="z-index: 0; position: relative; margin-top: 0; margin-bottom: 20px">' + toggleUpcomingLink + links + awardContainer + '</div>';
+    var allHtml =
+        '<div id="icm_award_html_container" ' +
+        'style="z-index: 0; position: relative; margin-top: 0; margin-bottom: 20px">' +
+            toggleUpcomingLink + links + awardContainer + '</div>';
 
     $('#icm_award_html_container, #ua_toggle_link_container').remove();
 
@@ -615,7 +674,7 @@ UpcomingAwardsOverview.prototype.htmlOut = function() {
 
     var _this = this;
 
-    $('a.icm_hide_list').on('click', function(e) {
+    $('a.icm_toggle_list').on('click', function(e) {
         e.preventDefault();
 
         var $parent = $(this).parent().parent(),
@@ -634,12 +693,9 @@ UpcomingAwardsOverview.prototype.htmlOut = function() {
             .filter(function() { // get all awards with the same url
                 return $(this).data('list-url') === listUrl;
             })
-            .toggleClass('hidden-list', hide).hide()
-            .find('.icm_hide_list > img').attr({
-                src: hide ? unhideIconData : hideIconData,
-                alt: (hide ? 'Unhide ' : 'Hide ') + 'Icon',
-                title: (hide ? 'Unhide ' : 'Hide ') + listTitle
-            });
+            .toggleClass('hidden-list', hide)
+            .hide() // = don't show in the current listing
+            .find('.icm_toggle_list > img').replaceWith(getIcon(!hide, listTitle));
 
         // save hidden lists
         gmSetValue('hidden_lists', JSON.stringify(_this.hiddenLists));

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -1710,10 +1710,15 @@ ICM_ListsTabDisplay.prototype.Attach = function() {
         _c = this.config;
 
     if (isOnMoviePage) {
-        var _b = this.block;
+        var lists = this.block.children();
 
         if (_c.sort_official) {
-            var officialLists = _b.children().has("ul.tagList a[href$='user%3Aicheckmovies']");
+            var officialLists = lists
+                .has("ul.tagList a[href$='user%3Aicheckmovies']")
+                .filter(function() {
+                    // icm bug: deleted lists reset to icheckmovies user
+                    return !$(this).find('.title').attr('href').endsWith('//');
+                });
             this.move(officialLists);
         }
 
@@ -1734,18 +1739,18 @@ ICM_ListsTabDisplay.prototype.Attach = function() {
         }
 
         if (_c.sort_filmos) {
-            var filmos = _b.children().filter(function() {
+            var filmos = lists.filter(function() {
                 return $(this).text().toLowerCase().indexOf('filmography') >= 0;
             });
             this.move(filmos);
         }
 
         // visual fix for edge cases when all lists are moved
-        _b.children().last().filter('.groupSeparator').hide();
+        lists.last().filter('.groupSeparator').hide();
     } else if (_c.redirect) { // = if on a list page
-        var linksTolists = $('.listItemMovie > .info > a:last-of-type');
+        var linksToLists = $('.listItemMovie > .info > a:last-of-type');
 
-        linksTolists.each(function () {
+        linksToLists.each(function () {
             var link = $(this),
                 url = link.attr('href').replace('?tags=user:icheckmovies', '');
             link.attr('href', url);

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -2014,7 +2014,7 @@ ExportLists.prototype.attach = function() {
 
         function encodeField(field) {
             return field.indexOf('"') !== -1 || field.indexOf(sep) !== -1 ?
-                   '"' + field.replace('"', '""', 'g') + '"' :
+                   '"' + field.replace(/"/g, '""') + '"' :
                    field;
         }
 

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -18,6 +18,13 @@
 // @grant          GM_getResourceText
 // ==/UserScript==
 
+// jscs:disable requireCamelCaseOrUpperCaseIdentifiers
+var gmSetValue = GM_setValue,
+    gmGetValue = GM_getValue,
+    gmAddStyle = GM_addStyle,
+    gmGetResourceText = GM_getResourceText;
+// jscs:enable requireCamelCaseOrUpperCaseIdentifiers
+
 //+ Jonas Raoni Soares Silva
 //@ http://jsfromhell.com/array/shuffle [rev. #1]
 var shuffle = function(v) {
@@ -67,16 +74,16 @@ function evalOrParse(str) {
 
 // ----- Objects -----
 
-function ICM_BaseFeature(config) {
+function BaseFeature(config) {
     this.updateConfig(config);
 }
 
-ICM_BaseFeature.prototype.settings = {
+BaseFeature.prototype.settings = {
     includes: [],
     excludes: []
 };
 
-ICM_BaseFeature.prototype.IsEnabled = function() {
+BaseFeature.prototype.isEnabled = function() {
     function testRegex(str) {
         return (new RegExp(str)).test(window.location.href);
     }
@@ -87,13 +94,13 @@ ICM_BaseFeature.prototype.IsEnabled = function() {
 
 // Add module options to the config;
 // Keeps loaded values, excludes outdated options, adds new options
-ICM_BaseFeature.prototype.updateConfig = function(config) {
+BaseFeature.prototype.updateConfig = function(config) {
     var module = this.settings.index,
         cur = {};
 
     $.each(this.settings.options, function(i, option) {
         var idx = option.name,
-            oldValue = config.Get(module + '.' + idx),
+            oldValue = config.get(module + '.' + idx),
             newValue = oldValue !== undefined ? oldValue : option.default;
 
         setProperty(idx, cur, newValue);
@@ -105,7 +112,7 @@ ICM_BaseFeature.prototype.updateConfig = function(config) {
 };
 
 // Config object constructor
-function ICM_Config() {
+function Config() {
     this.cfg = {
         script_config: { // script config
             version: '1.7.6.2',
@@ -113,12 +120,12 @@ function ICM_Config() {
         }
     };
 
-    this.Init();
+    this.init();
 }
 
 // Initialize stuff
-ICM_Config.prototype.Init = function() {
-    var oldcfg = evalOrParse(GM_getValue('icm_enhanced_cfg'));
+Config.prototype.init = function() {
+    var oldcfg = evalOrParse(gmGetValue('icm_enhanced_cfg'));
     if (!oldcfg) {
         return;
     }
@@ -131,29 +138,29 @@ ICM_Config.prototype.Init = function() {
     this.cfg = oldcfg;
 
     if (isUpdated) {
-        this.Save();
+        this.save();
     }
 };
 
 // Save config
-ICM_Config.prototype.Save = function() {
+Config.prototype.save = function() {
     // console.log("Saving config", this.cfg); // debug
-    GM_setValue( 'icm_enhanced_cfg', JSON.stringify(this.cfg));
+    gmSetValue( 'icm_enhanced_cfg', JSON.stringify(this.cfg));
 };
 
 // Get config value
-ICM_Config.prototype.Get = function( index ) {
+Config.prototype.get = function( index ) {
     return getProperty(index, this.cfg);
 };
 
 // Set config value
-ICM_Config.prototype.Set = function( index, value ) {
+Config.prototype.set = function( index, value ) {
     setProperty(index, this.cfg, value);
 };
 
 // Sets false to true and vice versa
-ICM_Config.prototype.Toggle = function( index ) {
-    var val = this.Get(index),
+Config.prototype.toggle = function( index ) {
+    var val = this.get(index),
         changeVal;
 
     if ( val === true || val === false ) {
@@ -163,16 +170,16 @@ ICM_Config.prototype.Toggle = function( index ) {
     } else {
         return false; // Couldn't toggle a value
     }
-    this.Set(index, changeVal);
+    this.set(index, changeVal);
     return true; // Value toggled
 };
 
-function ICM_ConfigWindow(Config) {
+function ConfigWindow(Config) {
     this.config = Config;
     this.modules = [];
 }
 
-ICM_ConfigWindow.prototype.addModule = function(module) {
+ConfigWindow.prototype.addModule = function(module) {
     if (!this.modules.some(function(m) {
         return m.title === module.title;
     })) {
@@ -180,14 +187,14 @@ ICM_ConfigWindow.prototype.addModule = function(module) {
     }
 };
 
-ICM_ConfigWindow.prototype.loadOptions = function(idx) {
+ConfigWindow.prototype.loadOptions = function(idx) {
     var m = this.modules[idx],
         str = '<p>' + m.desc + '</p>',
         needsExtraInit = false;
 
     for (var opt of m.options) {
         var index = m.index + '.' + opt.name,
-            optValue = this.config.Get(index), // always up to date
+            optValue = this.config.get(index), // always up to date
             indexAttr = ' data-cfg-index="' + index + '"';
 
         if (opt.type === 'checkbox') {
@@ -220,7 +227,7 @@ ICM_ConfigWindow.prototype.loadOptions = function(idx) {
     }
 };
 
-ICM_ConfigWindow.prototype.initColorPickers = function() {
+ConfigWindow.prototype.initColorPickers = function() {
     $('.colorpicker').each(function() {
         var $t = $(this);
         $t.spectrum({
@@ -237,7 +244,7 @@ ICM_ConfigWindow.prototype.initColorPickers = function() {
     });
 };
 
-ICM_ConfigWindow.prototype.build = function() {
+ConfigWindow.prototype.build = function() {
     // Sort module list by title
     this.modules.sort(function(a, b) { return a.title > b.title ? 1 : -1; });
 
@@ -261,7 +268,7 @@ ICM_ConfigWindow.prototype.build = function() {
         '#configSave { position: absolute; bottom:15px; left: 30px }' +
         'hr { border:0; height:1px; width:100%; background-color:#aaa; }';
 
-    GM_addStyle(customCSS);
+    gmAddStyle(customCSS);
 
     var moduleList = '<select id="modulelist" name="modulelist">';
     for (var i = 0; i < this.modules.length; ++i) {
@@ -290,15 +297,15 @@ ICM_ConfigWindow.prototype.build = function() {
             return;
         }
 
-        if ( !_t.config.Toggle(index) ) {
-            _t.config.Set( index, $(this).val() );
+        if ( !_t.config.toggle(index) ) {
+            _t.config.set( index, $(this).val() );
         }
 
         $('button#configSave').prop('disabled', false);
     });
 
     $('div#cfgModal').on( 'click', 'button#configSave', function() {
-        _t.config.Save();
+        _t.config.save();
 
         $(this).prop('disabled', true);
     });
@@ -314,72 +321,72 @@ ICM_ConfigWindow.prototype.build = function() {
     $('#cfgModal').jqm( { trigger: 'a#icm_enhanced_cfg' } );
 
     // Initialize spectrum plugin
-    GM_addStyle(GM_getResourceText('spectrumCss'));
+    gmAddStyle(gmGetResourceText('spectrumCss'));
 };
 
 // Inherit methods from BaseFeature
-ICM_RandomFilmLink.prototype = Object.create(ICM_BaseFeature.prototype);
-ICM_RandomFilmLink.prototype.constructor = ICM_RandomFilmLink;
+RandomFilmLink.prototype = Object.create(BaseFeature.prototype);
+RandomFilmLink.prototype.constructor = RandomFilmLink;
 
-function ICM_RandomFilmLink(config) {
-    ICM_BaseFeature.call(this, config);
+function RandomFilmLink(config) {
+    BaseFeature.call(this, config);
 
-    this.random_nums = [];
+    this.randomNums = [];
 }
 
 // Creates an element and inserts it into the DOM
-ICM_RandomFilmLink.prototype.Attach = function() {
+RandomFilmLink.prototype.attach = function() {
     if ( this.config.enabled ) {
-        var random_film = '<span style="float:right; margin-left: 15px"><a href="#" id="random_film">Help me pick a film!</a></span>';
+        var randomFilm = '<span style="float:right; margin-left: 15px"><a href="#" id="randomFilm">Help me pick a film!</a></span>';
 
         if ( $('div#list_container').length !== 1 ) {
-            var container = '<div id="list_container" style="height: 35px; position: relative">' + random_film + '</div>';
+            var container = '<div id="list_container" style="height: 35px; position: relative">' + randomFilm + '</div>';
 
             $('#movies').parent().before( container );
         } else {
-            $('div#list_container').append( random_film );
+            $('div#list_container').append( randomFilm );
         }
 
         var that = this;
 
-        $('div#list_container').on( 'click', 'a#random_film', function(e) {
+        $('div#list_container').on( 'click', 'a#randomFilm', function(e) {
             e.preventDefault();
 
-            that.PickRandomFilm();
+            that.pickRandomFilm();
         });
     }
 };
 
 // Displays a random film on a list
-ICM_RandomFilmLink.prototype.PickRandomFilm = function() {
+RandomFilmLink.prototype.pickRandomFilm = function() {
     var $unchecked = $('ol#itemListMovies > li.unchecked'),
-        rand_num;
+        randNum;
 
     if ( $unchecked.length > 0 ) {
         if ( this.config.unique ) {
             // Generate random numbers
-            if ( this.random_nums.length === 0 ) {
-                // Populate random_nums
+            if ( this.randomNums.length === 0 ) {
+                // Populate randomNums
                 for ( var i = 0; i < $unchecked.length; i++ ) {
-                    this.random_nums.push( i );
+                    this.randomNums.push( i );
                 }
 
                 // Shuffle the results for randomness in-place
-                shuffle( this.random_nums );
+                shuffle( this.randomNums );
             }
 
-            rand_num = this.random_nums.pop();
+            randNum = this.randomNums.pop();
         } else {
-            rand_num = Math.floor( Math.random() * $unchecked.length );
+            randNum = Math.floor( Math.random() * $unchecked.length );
         }
 
         $('ol#itemListMovies > li').hide();
 
-        $( $unchecked[ rand_num ] ).show();
+        $( $unchecked[ randNum ] ).show();
     }
 };
 
-ICM_RandomFilmLink.prototype.settings = {
+RandomFilmLink.prototype.settings = {
     title: 'Random film link',
     desc: 'Displays "Help me pick a film" link on individual lists',
     index: 'random_film',
@@ -399,31 +406,31 @@ ICM_RandomFilmLink.prototype.settings = {
 };
 
 // Inherit methods from BaseFeature
-ICM_UpcomingAwardsList.prototype = Object.create(ICM_BaseFeature.prototype);
-ICM_UpcomingAwardsList.prototype.constructor = ICM_UpcomingAwardsList;
+UpcomingAwardsList.prototype = Object.create(BaseFeature.prototype);
+UpcomingAwardsList.prototype.constructor = UpcomingAwardsList;
 
-function ICM_UpcomingAwardsList(config) {
-    ICM_BaseFeature.call(this, config);
+function UpcomingAwardsList(config) {
+    BaseFeature.call(this, config);
 }
 
-ICM_UpcomingAwardsList.prototype.Attach = function() {
+UpcomingAwardsList.prototype.attach = function() {
     if ( this.config.enabled && $('#itemListMovies').length ) {
-        var total_items = parseInt($('li#listFilterMovies').text().match(/\d+/));
+        var totalItems = parseInt($('li#listFilterMovies').text().match(/\d+/));
         var checks      = parseInt($('#topListMoviesCheckedCount').text().match(/\d+/));
 
         var statistics = '<span><b>Upcoming awards:</b>';
 
         var abs = this.config.show_absolute;
-        var get_span = function(award, cutoff) {
-            var num = Math.ceil(total_items * cutoff) - checks;
+        var getSpan = function(award, cutoff) {
+            var num = Math.ceil(totalItems * cutoff) - checks;
             if (!abs && num <= 0) {
                 return '';
             }
             return '<span style="margin-left: 30px">' + award + ': <b>' + num + '</b></span>';
         };
 
-        statistics += get_span('Bronze', 0.5) + get_span('Silver', 0.75) +
-                      get_span('Gold', 0.9) + get_span('Platinum', 1);
+        statistics += getSpan('Bronze', 0.5) + getSpan('Silver', 0.75) +
+                      getSpan('Gold', 0.9) + getSpan('Platinum', 1);
 
         if ( $('div#list_container').length !== 1 ) {
             var container = '<div id="list_container" style="height: 35px; position: relative">' + statistics + '</div>';
@@ -435,7 +442,7 @@ ICM_UpcomingAwardsList.prototype.Attach = function() {
     }
 };
 
-ICM_UpcomingAwardsList.prototype.settings = {
+UpcomingAwardsList.prototype.settings = {
     title: 'Upcoming awards (individual lists)',
     desc: 'Displays upcoming awards on individual lists',
     index: 'ua_list',
@@ -455,24 +462,24 @@ ICM_UpcomingAwardsList.prototype.settings = {
 };
 
 // Inherit methods from BaseFeature
-ICM_UpcomingAwardsOverview.prototype = Object.create(ICM_BaseFeature.prototype);
-ICM_UpcomingAwardsOverview.prototype.constructor = ICM_UpcomingAwardsOverview;
+UpcomingAwardsOverview.prototype = Object.create(BaseFeature.prototype);
+UpcomingAwardsOverview.prototype.constructor = UpcomingAwardsOverview;
 
-function ICM_UpcomingAwardsOverview(config) {
-    ICM_BaseFeature.call(this, config);
+function UpcomingAwardsOverview(config) {
+    BaseFeature.call(this, config);
 
     this.lists = [];
-    this.hidden_lists = [];
+    this.hiddenLists = [];
 }
 
-ICM_UpcomingAwardsOverview.prototype.Attach = function() {
+UpcomingAwardsOverview.prototype.attach = function() {
     if ( this.config.enabled ) {
         if ( this.config.autoload ) {
-            this.LoadAwardData();
+            this.loadAwardData();
         } else {
-            var load_link = '<p id="lad_container"><a id="load_award_data" href="#">Load upcoming awards for this user</a></p>';
+            var loadLink = '<p id="lad_container"><a id="load_award_data" href="#">Load upcoming awards for this user</a></p>';
 
-            $('#listOrdering').before(load_link);
+            $('#listOrdering').before(loadLink);
 
             var that = this;
 
@@ -481,124 +488,124 @@ ICM_UpcomingAwardsOverview.prototype.Attach = function() {
 
                 $( e.target ).remove();
 
-                that.LoadAwardData();
+                that.loadAwardData();
             });
         }
     }
 };
 
-ICM_UpcomingAwardsOverview.prototype.LoadAwardData = function() {
+UpcomingAwardsOverview.prototype.loadAwardData = function() {
     this.lists = [];
-    this.hidden_lists = evalOrParse(GM_getValue('hidden_lists', '[]'));
+    this.hiddenLists = evalOrParse(gmGetValue('hidden_lists', '[]'));
 
-    this.PopulateLists();
-    this.SortLists();
-    this.HTMLOut();
+    this.populateLists();
+    this.sortLists();
+    this.htmlOut();
 };
 
-ICM_UpcomingAwardsOverview.prototype.PopulateLists = function() {
+UpcomingAwardsOverview.prototype.populateLists = function() {
     var that = this,
-        $all_lists = $('ol#progressall, ol#itemListToplists').children('li'),
+        $allLists = $('ol#progressall, ol#itemListToplists').children('li'),
         sel = {progress: {rank: 'span.rank', title: 'h3 > a'},
                lists: {rank: 'span.info > strong:first', title: 'h2 > a.title'}},
         // use different selectors depending on page
         curSel = location.href.indexOf('progress') !== -1 ?
                  sel.progress : sel.lists,
-        award_types = [['Platinum', 1], ['Gold', 0.9], ['Silver', 0.75], ['Bronze', 0.5]];
+        awardTypes = [['Platinum', 1], ['Gold', 0.9], ['Silver', 0.75], ['Bronze', 0.5]];
 
-    $all_lists.each(function() {
+    $allLists.each(function() {
         var $el = $(this),
-            count_arr = $el.find(curSel.rank).text().match(/\d+/g);
+            countArr = $el.find(curSel.rank).text().match(/\d+/g);
 
-        if (!count_arr) {
+        if (!countArr) {
             return;
         }
 
-        var checks      = parseInt( count_arr[0], 10 ),
-            total_items = parseInt( count_arr[1], 10 ),
-            $t          = $el.find(curSel.title),
-            list_title  = $t.attr('title').replace(/^View the | top list$/g, ''),
-            list_url    = $t.attr('href');
+        var checks     = parseInt( countArr[0], 10 ),
+            totalItems = parseInt( countArr[1], 10 ),
+            $t         = $el.find(curSel.title),
+            listTitle  = $t.attr('title').replace(/^View the | top list$/g, ''),
+            listUrl    = $t.attr('href');
 
-        award_types.forEach(function(award) {
-            var award_checks = Math.ceil(total_items * award[1]) - checks;
-            if (award_checks <= 0) {
+        awardTypes.forEach(function(award) {
+            var awardChecks = Math.ceil(totalItems * award[1]) - checks;
+            if (awardChecks <= 0) {
                 return false; // exit loop; the order of array is important!
             }
 
             that.lists.push({
-                'award_checks': award_checks,
-                'award_type': award[0],
-                'list_title': list_title,
-                'list_url': list_url
+                'awardChecks': awardChecks,
+                'awardType':   award[0],
+                'listTitle':   listTitle,
+                'listUrl':     listUrl
             });
         });
     });
 };
 
-ICM_UpcomingAwardsOverview.prototype.SortLists = function() {
+UpcomingAwardsOverview.prototype.sortLists = function() {
     // sort lists array by least required checks ASC,
     // then by awards where checks are equal ASC, then by list title ASC
-    var award_order = { 'Bronze': 0, 'Silver': 1, 'Gold': 2, 'Platinum': 3 };
+    var awardOrder = { 'Bronze': 0, 'Silver': 1, 'Gold': 2, 'Platinum': 3 };
     this.lists.sort(function(a, b) {
-        if (a.award_checks < b.award_checks) {
+        if (a.awardChecks < b.awardChecks) {
             return -1;
-        } else if (a.award_checks > b.award_checks) {
+        } else if (a.awardChecks > b.awardChecks) {
             return 1;
-        } else if (award_order[a.award_type] < award_order[b.award_type]) {
+        } else if (awardOrder[a.awardType] < awardOrder[b.awardType]) {
             return -1;
-        } else if (award_order[a.award_type] > award_order[b.award_type]) {
+        } else if (awardOrder[a.awardType] > awardOrder[b.awardType]) {
             return 1;
-        } else if (a.list_title < b.list_title) {
+        } else if (a.listTitle < b.listTitle) {
             return -1;
-        } else if (a.list_title > b.list_title) {
+        } else if (a.listTitle > b.listTitle) {
             return 1;
         }
         return 0;
     });
 };
 
-ICM_UpcomingAwardsOverview.prototype.HTMLOut = function() {
-    var unhide_icon_data = 'data:text/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAGrSURBVDjLvZPZLkNhFIV75zjvYm7VGFNCqoZUJ+roKUUpjRuqp61Wq0NKDMelGGqOxBSUIBKXWtWGZxAvobr8lWjChRgSF//dv9be+9trCwAI/vIE/26gXmviW5bqnb8yUK028qZjPfoPWEj4Ku5HBspgAz941IXZeze8N1bottSo8BTZviVWrEh546EO03EXpuJOdG63otJbjBKHkEp/Ml6yNYYzpuezWL4s5VMtT8acCMQcb5XL3eJE8VgBlR7BeMGW9Z4yT9y1CeyucuhdTGDxfftaBO7G4L+zg91UocxVmCiy51NpiP3n2treUPujL8xhOjYOzZYsQWANyRYlU4Y9Br6oHd5bDh0bCpSOixJiWx71YY09J5pM/WEbzFcDmHvwwBu2wnikg+lEj4mwBe5bC5h1OUqcwpdC60dxegRmR06TyjCF9G9z+qM2uCJmuMJmaNZaUrCSIi6X+jJIBBYtW5Cge7cd7sgoHDfDaAvKQGAlRZYc6ltJlMxX03UzlaRlBdQrzSCwksLRbOpHUSb7pcsnxCCwngvM2Rm/ugUCi84fycr4l2t8Bb6iqTxSCgNIAAAAAElFTkSuQmCC';
-    var hide_icon_data = 'data:text/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADtSURBVHjajFC7DkFREJy9iXg0t+EHRKJDJSqRuIVaJT7AF+jR+xuNRiJyS8WlRaHWeOU+kBy7eyKhs8lkJrOzZ3OWzMAD15gxYhB+yzAm0ndez+eYMYLngdkIf2vpSYbCfsNkOx07n8kgWa1UpptNII5VR/M56Nyt6Qq33bbhQsHy6aR0WSyEyEmiCG6vR2ffB65X4HCwYC2e9CTjJGGok4/7Hcjl+ImLBWv1uCRDu3peV5eGQ2C5/P1zq4X9dGpXP+LYhmYz4HbDMQgUosWTnmQoKKf0htVKBZvtFsx6S9bm48ktaV3EXwd/CzAAVjt+gHT5me0AAAAASUVORK5CYII=';
+UpcomingAwardsOverview.prototype.htmlOut = function() {
+    var unhideIconData = 'data:text/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAGrSURBVDjLvZPZLkNhFIV75zjvYm7VGFNCqoZUJ+roKUUpjRuqp61Wq0NKDMelGGqOxBSUIBKXWtWGZxAvobr8lWjChRgSF//dv9be+9trCwAI/vIE/26gXmviW5bqnb8yUK028qZjPfoPWEj4Ku5HBspgAz941IXZeze8N1bottSo8BTZviVWrEh546EO03EXpuJOdG63otJbjBKHkEp/Ml6yNYYzpuezWL4s5VMtT8acCMQcb5XL3eJE8VgBlR7BeMGW9Z4yT9y1CeyucuhdTGDxfftaBO7G4L+zg91UocxVmCiy51NpiP3n2treUPujL8xhOjYOzZYsQWANyRYlU4Y9Br6oHd5bDh0bCpSOixJiWx71YY09J5pM/WEbzFcDmHvwwBu2wnikg+lEj4mwBe5bC5h1OUqcwpdC60dxegRmR06TyjCF9G9z+qM2uCJmuMJmaNZaUrCSIi6X+jJIBBYtW5Cge7cd7sgoHDfDaAvKQGAlRZYc6ltJlMxX03UzlaRlBdQrzSCwksLRbOpHUSb7pcsnxCCwngvM2Rm/ugUCi84fycr4l2t8Bb6iqTxSCgNIAAAAAElFTkSuQmCC';
+    var hideIconData = 'data:text/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADtSURBVHjajFC7DkFREJy9iXg0t+EHRKJDJSqRuIVaJT7AF+jR+xuNRiJyS8WlRaHWeOU+kBy7eyKhs8lkJrOzZ3OWzMAD15gxYhB+yzAm0ndez+eYMYLngdkIf2vpSYbCfsNkOx07n8kgWa1UpptNII5VR/M56Nyt6Qq33bbhQsHy6aR0WSyEyEmiCG6vR2ffB65X4HCwYC2e9CTjJGGok4/7Hcjl+ImLBWv1uCRDu3peV5eGQ2C5/P1zq4X9dGpXP+LYhmYz4HbDMQgUosWTnmQoKKf0htVKBZvtFsx6S9bm48ktaV3EXwd/CzAAVjt+gHT5me0AAAAASUVORK5CYII=';
 
-    var list_table = '<table id="award_table"><thead><tr id="award_table_head"><th>Awards</th><th>Checks</th><th>List title</th><th>(Un)Hide</th></tr></head><tbody>';
+    var listTable = '<table id="award_table"><thead><tr id="award_table_head"><th>Awards</th><th>Checks</th><th>List title</th><th>(Un)Hide</th></tr></head><tbody>';
 
     for ( var i = 0; i < this.lists.length; i++ ) {
         var el = this.lists[i],
-            unhide_icon = '<img title="Unhide ' + el.list_title + '" alt="Unhide icon" src="' + unhide_icon_data + '">',
-            hide_icon = '<img title="Hide ' + el.list_title + '" alt="Hide icon" src="' + hide_icon_data + '">',
-            is_hidden = this.hidden_lists.indexOf(el.list_url) !== -1;
+            unhideIcon = '<img title="Unhide ' + el.listTitle + '" alt="Unhide icon" src="' + unhideIconData + '">',
+            hideIcon = '<img title="Hide ' + el.listTitle + '" alt="Hide icon" src="' + hideIconData + '">',
+            isHidden = this.hiddenLists.indexOf(el.listUrl) !== -1;
 
-        list_table  += '<tr class="' + (is_hidden ? 'hidden-list' : '') +
-            '" data-award-type="' + el.award_type + '" data-list-url="' + el.list_url + '">' +
-            '<td style="width: 65px">' + el.award_type + '</td>' +
-            '<td style="width: 65px">' + el.award_checks + '</td>' +
-            '<td><div style="height: 28px; overflow: hidden"><a class="list-title" href="' + el.list_url + '">' + el.list_title + '</a></div></td>' +
-            '<td style="width: 70px"><a href="#" class="icm_hide_list">' + (is_hidden ? unhide_icon : hide_icon) + '</a></td></tr>';
+        listTable  += '<tr class="' + (isHidden ? 'hidden-list' : '') +
+            '" data-award-type="' + el.awardType + '" data-list-url="' + el.listUrl + '">' +
+            '<td style="width: 65px">' + el.awardType + '</td>' +
+            '<td style="width: 65px">' + el.awardChecks + '</td>' +
+            '<td><div style="height: 28px; overflow: hidden"><a class="list-title" href="' + el.listUrl + '">' + el.listTitle + '</a></div></td>' +
+            '<td style="width: 70px"><a href="#" class="icm_hide_list">' + (isHidden ? unhideIcon : hideIcon) + '</a></td></tr>';
     }
 
-    list_table += '</tbody></table>';
+    listTable += '</tbody></table>';
 
     // build the html...
-    var toggle_upcoming_link = '<p id="ua_toggle_link_container" style="position: relative; left:0; top:0; width: 200px"><a id="toggle_upcoming_awards" href="#"><span class="_show" style="display: none">Show upcoming awards</span><span class="_hide">Hide upcoming awards</span></a></p>';
-    var toggle_full_link     = '<a id="toggle_full_list" href="#"><span class="_show">Show full list</span><span class="_hide" style="display: none">Minimize full list</span></a>';
-    var toggle_hidden_link   = '<a id="toggle_hidden_list" href="#">Show hidden</a>';
+    var toggleUpcomingLink = '<p id="ua_toggle_link_container" style="position: relative; left:0; top:0; width: 200px"><a id="toggle_upcoming_awards" href="#"><span class="_show" style="display: none">Show upcoming awards</span><span class="_hide">Hide upcoming awards</span></a></p>';
+    var toggleFullLink     = '<a id="toggle_full_list" href="#"><span class="_show">Show full list</span><span class="_hide" style="display: none">Minimize full list</span></a>';
+    var toggleHiddenLink   = '<a id="toggle_hidden_list" href="#">Show hidden</a>';
 
     var links = '<p id="award_display_links" style="position: absolute; right: 0; top: 0; font-weight: bold">Display: <a id="display_all" href="#">All</a>, ' +
         '<a id="display_bronze" href="#">Bronze</a>, <a id="display_silver" href="#">Silver</a>, <a id="display_gold" href="#">Gold</a>, ' +
-        '<a id="display_platinum" href="#">Platinum</a>, ' + toggle_full_link + ', ' + toggle_hidden_link + '</p>';
+        '<a id="display_platinum" href="#">Platinum</a>, ' + toggleFullLink + ', ' + toggleHiddenLink + '</p>';
 
-    var award_container = '<div id="award_container" class="container" style="position: relative; top: 0; width: 830px; height: 240px; overflow: scroll">' + list_table + '</div>';
+    var awardContainer = '<div id="award_container" class="container" style="position: relative; top: 0; width: 830px; height: 240px; overflow: scroll">' + listTable + '</div>';
 
-    var all_html = '<div id="icm_award_html_container" style="z-index: 0; position: relative; margin-top: 0; margin-bottom: 20px">' + toggle_upcoming_link + links + award_container + '</div>';
+    var allHtml = '<div id="icm_award_html_container" style="z-index: 0; position: relative; margin-top: 0; margin-bottom: 20px">' + toggleUpcomingLink + links + awardContainer + '</div>';
 
     $('#icm_award_html_container, #ua_toggle_link_container').remove();
 
     if (location.href.indexOf('progress') !== -1) {
-        $('#listOrdering').before(all_html);
+        $('#listOrdering').before(allHtml);
     } else {
-        $('#itemContainer').before(all_html);
+        $('#itemContainer').before(allHtml);
     }
 
     var $lists = $('#award_table > tbody > tr');
@@ -612,30 +619,30 @@ ICM_UpcomingAwardsOverview.prototype.HTMLOut = function() {
         e.preventDefault();
 
         var $parent = $(this).parent().parent(),
-            list_title = $.trim($parent.find('.list-title').text()),
-            list_url = $parent.data('list-url'),
-            ind = _this.hidden_lists.indexOf(list_url),
+            listTitle = $.trim($parent.find('.list-title').text()),
+            listUrl = $parent.data('list-url'),
+            ind = _this.hiddenLists.indexOf(listUrl),
             hide = ind === -1;
 
         if (hide) { // hide list
-            _this.hidden_lists.push(list_url);
+            _this.hiddenLists.push(listUrl);
         } else { // unhide list
-            _this.hidden_lists.splice(ind, 1);
+            _this.hiddenLists.splice(ind, 1);
         }
 
         $lists.filter(hide ? 'tr' : 'tr.hidden-list')
             .filter(function() { // get all awards with the same url
-                return $(this).data('list-url') === list_url;
+                return $(this).data('list-url') === listUrl;
             })
             .toggleClass('hidden-list', hide).hide()
             .find('.icm_hide_list > img').attr({
-                src: hide ? unhide_icon_data : hide_icon_data,
+                src: hide ? unhideIconData : hideIconData,
                 alt: (hide ? 'Unhide ' : 'Hide ') + 'Icon',
-                title: (hide ? 'Unhide ' : 'Hide ') + list_title
+                title: (hide ? 'Unhide ' : 'Hide ') + listTitle
             });
 
         // save hidden lists
-        GM_setValue('hidden_lists', JSON.stringify(_this.hidden_lists));
+        gmSetValue('hidden_lists', JSON.stringify(_this.hiddenLists));
     });
 
     $('#toggle_hidden_list').on('click', function(e) {
@@ -662,10 +669,10 @@ ICM_UpcomingAwardsOverview.prototype.HTMLOut = function() {
     $('#award_display_links').on('click', 'a#display_bronze, a#display_silver, a#display_gold, a#display_platinum', function(e) {
         e.preventDefault();
 
-        var award_type = $(this).attr('id').split('_')[1];
+        var awardType = $(this).attr('id').split('_')[1];
         $lists.hide().filter(function() {
             return !$(this).hasClass('hidden-list') &&
-                    $(this).data('award-type').toLowerCase() === award_type;
+                    $(this).data('award-type').toLowerCase() === awardType;
         }).show();
     });
 
@@ -684,7 +691,7 @@ ICM_UpcomingAwardsOverview.prototype.HTMLOut = function() {
     });
 };
 
-ICM_UpcomingAwardsOverview.prototype.settings = {
+UpcomingAwardsOverview.prototype.settings = {
     title: 'Upcoming awards overview',
     desc: 'Displays upcoming awards on progress page',
     index: 'ua',
@@ -707,34 +714,34 @@ ICM_UpcomingAwardsOverview.prototype.settings = {
 };
 
 // Inherit methods from BaseFeature
-ICM_ListCustomColors.prototype = Object.create(ICM_BaseFeature.prototype);
-ICM_ListCustomColors.prototype.constructor = ICM_ListCustomColors;
+ListCustomColors.prototype = Object.create(BaseFeature.prototype);
+ListCustomColors.prototype.constructor = ListCustomColors;
 
-function ICM_ListCustomColors(config) {
-    ICM_BaseFeature.call(this, config);
+function ListCustomColors(config) {
+    BaseFeature.call(this, config);
 }
 
-ICM_ListCustomColors.prototype.Attach = function() {
+ListCustomColors.prototype.attach = function() {
     if ( this.config.enabled ) {
-        var list_colors_css = '';
+        var listColorsCss = '';
 
         var buildCSS = function(className, color) {
             if (!color.length) {
                 return;
             }
             var sel = 'ol#itemListMovies li.' + className;
-            list_colors_css += sel + ', ' + sel + ' ul.optionIconMenu { background-color: ' + color + ' !important; }';
+            listColorsCss += sel + ', ' + sel + ' ul.optionIconMenu { background-color: ' + color + ' !important; }';
         };
 
         buildCSS('favorite', this.config.colors.favorite);
         buildCSS('watch', this.config.colors.watchlist);
         buildCSS('hated', this.config.colors.disliked);
 
-        GM_addStyle(list_colors_css);
+        gmAddStyle(listColorsCss);
     }
 };
 
-ICM_ListCustomColors.prototype.settings = {
+ListCustomColors.prototype.settings = {
     title: 'Custom list colors',
     desc: 'Changes entry colors on lists to visually separate entries in your favorites/watchlist/dislikes',
     index: 'list_colors',
@@ -764,20 +771,20 @@ ICM_ListCustomColors.prototype.settings = {
 };
 
 // Inherit methods from BaseFeature
-ICM_ListCrossCheck.prototype = Object.create(ICM_BaseFeature.prototype);
-ICM_ListCrossCheck.prototype.constructor = ICM_ListCrossCheck;
+ListCrossCheck.prototype = Object.create(BaseFeature.prototype);
+ListCrossCheck.prototype.constructor = ListCrossCheck;
 
-function ICM_ListCrossCheck(config) {
-    ICM_BaseFeature.call(this, config);
+function ListCrossCheck(config) {
+    BaseFeature.call(this, config);
 
-    this.activated_once = false;
-    this.Init();
+    this.activatedOnce = false;
+    this.init();
 }
 
 /**
  * Initialize object variables
  */
-ICM_ListCrossCheck.prototype.Init = function() {
+ListCrossCheck.prototype.init = function() {
     this.activated = false;
 
     // array of movie objects
@@ -787,16 +794,16 @@ ICM_ListCrossCheck.prototype.Init = function() {
     this.toplists = [];
 
     // number of total toplists
-    this.num_toplists = 0;
+    this.numToplists = 0;
 
     // cross-referencing in progress
-    this.in_progress = false;
+    this.inProgress = false;
 
     // current top list's number that is checked
-    this.sequence_number = 0;
+    this.sequenceNumber = 0;
 };
 
-ICM_ListCrossCheck.prototype.Attach = function() {
+ListCrossCheck.prototype.attach = function() {
     if (this.config.enabled && $('#itemListToplists').length) {
         var actions = '<div id="crActions" style="margin-bottom: 18px"><button id="cfgListCCActivate">Activate CR</button></div>';
 
@@ -807,9 +814,9 @@ ICM_ListCrossCheck.prototype.Attach = function() {
         $('div#crActions').on( 'click', 'button#cfgListCCActivate', function() {
             $(this).prop('disabled', true);
 
-            _t.CreateTab();
+            _t.createTab();
 
-            _t.Activate();
+            _t.activate();
         });
 
         var customCSS = '<style type="text/css">' +
@@ -823,8 +830,8 @@ ICM_ListCrossCheck.prototype.Attach = function() {
     }
 };
 
-ICM_ListCrossCheck.prototype.Activate = function() {
-    this.Init();
+ListCrossCheck.prototype.activate = function() {
+    this.init();
 
     this.activated = true;
 
@@ -833,14 +840,14 @@ ICM_ListCrossCheck.prototype.Activate = function() {
     $('button#cfgListCCActivate').after(' <button id="cfgListCCDeactivate">Deactivate</button>');
 
     $('div#crActions').on('click', 'button#cfgListCCDeactivate', function() {
-        _t.Deactivate();
+        _t.deactivate();
 
         $('button#cfgListCCActivate').prop('disabled', false);
     });
 
-    if ( !this.activated_once ) { // ff 3.6 compatibility (ff 3.6 fails to unbind the events in all possible ways)
+    if ( !this.activatedOnce ) { // ff 3.6 compatibility (ff 3.6 fails to unbind the events in all possible ways)
         $('ol#itemListToplists li').on('click mouseover mouseout', function(e) {
-            if ( _t.activated && !_t.in_progress ) { // ff 3.6 compatibility
+            if ( _t.activated && !_t.inProgress ) { // ff 3.6 compatibility
                 // these event actions must not work for cloned toplists under the selected tab
                 if ( !$(this).hasClass('icme_listcc') ) {
                     if ( e.type === 'mouseover' && !$(this).hasClass('icme_listcc_selected') ) {
@@ -862,75 +869,75 @@ ICM_ListCrossCheck.prototype.Activate = function() {
             }
         });
 
-        this.activated_once = true;
+        this.activatedOnce = true;
     }
 };
 
-ICM_ListCrossCheck.prototype.Deactivate = function() {
-    var selected_toplists = $('li.icme_listcc_selected', 'ul#topLists');
+ListCrossCheck.prototype.deactivate = function() {
+    var selectedToplists = $('li.icme_listcc_selected', 'ul#topLists');
 
     // if there's still selected top lists, change them back to normal
-    $(selected_toplists).removeClass('icme_listcc_selected').find('span.percentage').show();
+    $(selectedToplists).removeClass('icme_listcc_selected').find('span.percentage').show();
 
     $('ol#itemListToplists').children('li').removeClass('icme_listcc_selected').removeClass('icme_listcc_hover');
     $('button#icme_listcc_check, button#cfgListCCDeactivate').remove();
     $('li#topListCategoryCCSelected').remove();
     $('button#cfgListCCActivate').prop('disabled', false);
 
-    this.Init();
+    this.init();
 };
 
 /**
  * Check through every selected top list
  */
-ICM_ListCrossCheck.prototype.Check = function() {
-    var toplist_cnt = $('ol#itemListToplists');
+ListCrossCheck.prototype.check = function() {
+    var toplistCont = $('ol#itemListToplists');
 
     // make selected top lists normal under the regular tabs
-    toplist_cnt.children('li.icme_listcc_selected').removeClass('icme_listcc_selected').find('span.percentage').show();
+    toplistCont.children('li.icme_listcc_selected').removeClass('icme_listcc_selected').find('span.percentage').show();
 
     // get selected top lists
-    var jq_toplists = toplist_cnt.children('li.icme_listcc');
+    var $toplists = toplistCont.children('li.icme_listcc');
 
-    this.num_toplists = jq_toplists.length;
-    this.in_progress = true;
+    this.numToplists = $toplists.length;
+    this.inProgress = true;
 
     // sort selected top lists in ascending order by number of unchecked films
-    var get_unchecked = function(x) {
+    var getUnchecked = function(x) {
         var checks = $(x).find('span.info > strong:first').text().split('/');
         return checks[1] - checks[0];
     };
-    jq_toplists.sort(function(a, b) {
-        return get_unchecked(a) < get_unchecked(b) ? -1 : 1;
+    $toplists.sort(function(a, b) {
+        return getUnchecked(a) < getUnchecked(b) ? -1 : 1;
     });
 
     // make selected toplists highlighted under the selected tab
-    jq_toplists.addClass('icme_listcc_selected').find('span.percentage').hide();
+    $toplists.addClass('icme_listcc_selected').find('span.percentage').hide();
 
-    this.toplists = jq_toplists.get();
-    this.GetUncheckedFilms(this.toplists[this.sequence_number]);
+    this.toplists = $toplists.get();
+    this.getUncheckedFilms(this.toplists[this.sequenceNumber]);
 };
 
 /**
  * Get unchecked films from a top list
  *
- * @param list_elem jQuery object of the top list element
+ * @param listElem jQuery object of the top list element
  */
-ICM_ListCrossCheck.prototype.GetUncheckedFilms = function(list_elem) {
-    var url = $(list_elem).find('a').attr('href');
+ListCrossCheck.prototype.getUncheckedFilms = function(listElem) {
+    var url = $(listElem).find('a').attr('href');
 
-    $(list_elem).addClass('icme_listcc_pending');
+    $(listElem).addClass('icme_listcc_pending');
 
     var _t = this;
 
     $.get(url, function(response) {
-        $(list_elem).removeClass('icme_listcc_selected icme_listcc_pending').find('span.percentage').show();
+        $(listElem).removeClass('icme_listcc_selected icme_listcc_pending').find('span.percentage').show();
 
         var filter = _t.config.checks ? '' : 'li.unchecked';
         // the site returns html with extra whitespace
         var unchecked = $($.parseHTML(response)).find('ol#itemListMovies').children(filter);
 
-        _t.UpdateMovies( unchecked );
+        _t.updateMovies( unchecked );
     });
 };
 
@@ -939,37 +946,37 @@ ICM_ListCrossCheck.prototype.GetUncheckedFilms = function(list_elem) {
  *
  * @param content jQuery object that consists of unchecked movies (<li> elements) on a top list page
  */
-ICM_ListCrossCheck.prototype.UpdateMovies = function(content) {
-    var movie_titles = content.find('h2');
+ListCrossCheck.prototype.updateMovies = function(content) {
+    var movieTitles = content.find('h2');
 
-    this.sequence_number += 1;
+    this.sequenceNumber += 1;
 
     // keeps track if at least one movie on the current top list is also found on all previous top lists
     // if the script is currently checking for movies found on all top lists. it's a major optimization
     // that halts the script if there's a top list with 0 matches especially early on and doesn't go on
     // to check all the rest of the lists wasting time
-    var global_toplist_match = false;
+    var globalToplistMatch = false;
 
-    var show_perfect_matches = this.config.match_all;
+    var showPerfectMatches = this.config.match_all;
 
-    for (var i = 0; i < $(movie_titles).length; i++) {
+    for (var i = 0; i < $(movieTitles).length; i++) {
         var found = false,
-            cur_title = $(movie_titles[i]),
-            movie = $.trim(cur_title.text()),
-            movie_url = cur_title.find('a').attr('href'),
-            movie_year = cur_title.next('span.info').children('a:first').text();
+            curTitle = $(movieTitles[i]),
+            movie = $.trim(curTitle.text()),
+            movieUrl = curTitle.find('a').attr('href'),
+            movieYear = curTitle.next('span.info').children('a:first').text();
 
         for ( var j = 0; j < this.movies.length; j++ ) {
             // compare urls as they're guaranteed to be unique
             // in some cases movie title and release year are the same for different movies
             // which results in incorrect top list values
-            if ( movie_url === this.movies[j].u ) {
+            if ( movieUrl === this.movies[j].u ) {
                 this.movies[j].c += 1;
 
                 this.movies[j].jq.find('.rank').html(this.movies[j].c);
                 found = true;
 
-                global_toplist_match = true;
+                globalToplistMatch = true;
 
                 break;
             }
@@ -979,56 +986,56 @@ ICM_ListCrossCheck.prototype.UpdateMovies = function(content) {
         if ( !found ) {
             // add it to the main movies array only if the script is not checking for matches on all top lists
             // OR if the script is checking for matches on all top lists, but this is just the first top list
-            if ( !show_perfect_matches || this.sequence_number === 1 ) {
+            if ( !showPerfectMatches || this.sequenceNumber === 1 ) {
                 var $item = $(content[i]);
                 $item.find('.rank').html('0');
 
                 var itemid = $item.attr('id');
 
                 // check if owned
-                var owned = evalOrParse(GM_getValue('owned_movies', '[]'));
+                var owned = evalOrParse(gmGetValue('owned_movies', '[]'));
                 if (owned.indexOf(itemid) !== -1) {
                     $item.removeClass('notowned').addClass('owned');
                 }
 
                 // t = title, c = count, u = url, y = year
-                this.movies.push( {t: movie, c: 1, u: movie_url, y: movie_year, jq: $item} );
+                this.movies.push( {t: movie, c: 1, u: movieUrl, y: movieYear, jq: $item} );
             }
         }
     }
 
-    var has_toplists_left = this.sequence_number < this.toplists.length;
+    var hasToplistsLeft = this.sequenceNumber < this.toplists.length;
 
     // if finding movies on all selected top lists
-    if ( show_perfect_matches ) {
+    if ( showPerfectMatches ) {
         // if one or more movies was found on all selected top lists
-        if ( global_toplist_match ) {
+        if ( globalToplistMatch ) {
             // if not first top list, extract movies that have been found on all selected top lists
-            if ( this.sequence_number > 1 ) {
-                var cutoff = this.sequence_number;
+            if ( this.sequenceNumber > 1 ) {
+                var cutoff = this.sequenceNumber;
                 this.movies = $.grep(this.movies, function(el) {
                     return el.c === cutoff;
                 });
             }
         // if didn't find a single match, abort if it's the last or not the first top list
-        } else if ( this.sequence_number > 1 || !has_toplists_left ) {
+        } else if ( this.sequenceNumber > 1 || !hasToplistsLeft ) {
             this.movies = [];
-            has_toplists_left = false; // force output
+            hasToplistsLeft = false; // force output
         }
     }
 
     // if there's still more top lists
-    if ( has_toplists_left ) {
-        this.GetUncheckedFilms(this.toplists[this.sequence_number]);
+    if ( hasToplistsLeft ) {
+        this.getUncheckedFilms(this.toplists[this.sequenceNumber]);
     } else {
-        this.OutputMovies();
+        this.outputMovies();
     }
 };
 
-ICM_ListCrossCheck.prototype.OutputMovies = function() {
-    var show_perfect_matches = this.config.match_all;
+ListCrossCheck.prototype.outputMovies = function() {
+    var showPerfectMatches = this.config.match_all;
 
-    if ( !show_perfect_matches ) {
+    if ( !showPerfectMatches ) {
         var limit = this.config.match_min;
 
         if ( limit > 0 ) {
@@ -1117,12 +1124,12 @@ ICM_ListCrossCheck.prototype.OutputMovies = function() {
 
             for (var i = 0; i < $items.length; ++i) {
                 var $item = $($items[i]),
-                    found_toplists = $item.find('.rank').text(),
+                    foundToplists = $item.find('.rank').text(),
                     title = $item.find('h2').text().trim().replace('"', '""'),
                     year = $item.find('.info a:first').text(),
                     toplists = parseInt($item.find('.info a:last').text()),
                     imdburl = $item.find('.optionIMDB').attr('href'),
-                    line = '"' + found_toplists + '",' +
+                    line = '"' + foundToplists + '",' +
                            '"' + title + '",' +
                            '"' + year + '",' +
                            '"' + toplists + '",' +
@@ -1138,10 +1145,10 @@ ICM_ListCrossCheck.prototype.OutputMovies = function() {
         $('#itemContainer').after('<div id="icme-crossref-notfound">Found 0 movies.</div>');
     }
 
-    this.Deactivate();
+    this.deactivate();
 };
 
-ICM_ListCrossCheck.prototype.CreateTab = function() {
+ListCrossCheck.prototype.createTab = function() {
     if ($('#listFilterCRSelected').length) {
         return;
     }
@@ -1162,17 +1169,17 @@ ICM_ListCrossCheck.prototype.CreateTab = function() {
         });
         b.addClass('active');
 
-        if ( a === 'icme_listcc' && !_t.in_progress ) {
-            var $top_list_ul = $('ol#itemListToplists');
-            $top_list_ul.children('li.icme_listcc').remove();
+        if ( a === 'icme_listcc' && !_t.inProgress ) {
+            var $topListUl = $('ol#itemListToplists');
+            $topListUl.children('li.icme_listcc').remove();
 
-            var $top_lists = $top_list_ul.children('li.icme_listcc_selected').clone();
+            var $topLists = $topListUl.children('li.icme_listcc_selected').clone();
 
-            //$top_list_ul.children("li.icme_listcc_selected").removeClass("icme_listcc_selected");
+            //$topListUl.children("li.icme_listcc_selected").removeClass("icme_listcc_selected");
 
-            $top_lists.removeClass('imdb critics prizes website institute misc icme_listcc_selected').addClass('icme_listcc').find('span.percentage').show();
+            $topLists.removeClass('imdb critics prizes website institute misc icme_listcc_selected').addClass('icme_listcc').find('span.percentage').show();
 
-            $top_list_ul.append( $top_lists );
+            $topListUl.append( $topLists );
 
             if ( $('li.icme_listcc', 'ol#itemListToplists').length >= 2 && $('button#icme_listcc_check').length === 0 ) {
                 var btn = '<button id="icme_listcc_check">Cross-reference</button>';
@@ -1182,7 +1189,7 @@ ICM_ListCrossCheck.prototype.CreateTab = function() {
                 $('button#icme_listcc_check').on('click', function() {
                     $(this).prop('disabled', true);
 
-                    _t.Check();
+                    _t.check();
                 });
 
                 // Make the current tab work if we want to return to it
@@ -1210,7 +1217,7 @@ ICM_ListCrossCheck.prototype.CreateTab = function() {
     });
 };
 
-ICM_ListCrossCheck.prototype.settings = {
+ListCrossCheck.prototype.settings = {
     title: 'List cross-reference',
     desc: 'Cross-reference lists to find what films they share',
     index: 'list_cross_ref',
@@ -1240,24 +1247,24 @@ ICM_ListCrossCheck.prototype.settings = {
 };
 
 // Inherit methods from BaseFeature
-ICM_HideTags.prototype = Object.create(ICM_BaseFeature.prototype);
-ICM_HideTags.prototype.constructor = ICM_HideTags;
+HideTags.prototype = Object.create(BaseFeature.prototype);
+HideTags.prototype.constructor = HideTags;
 
-function ICM_HideTags(config) {
-    ICM_BaseFeature.call(this, config);
+function HideTags(config) {
+    BaseFeature.call(this, config);
 }
 
-ICM_HideTags.prototype.Attach = function() {
+HideTags.prototype.attach = function() {
     if (this.config.enabled) {
-        GM_addStyle('ol#itemListToplists li .info:last-child, ol#itemListMovies li .tagList { display: none !important; }');
+        gmAddStyle('ol#itemListToplists li .info:last-child, ol#itemListMovies li .tagList { display: none !important; }');
 
         if (this.config.show_hover) {
-            GM_addStyle('ol#itemListToplists li:hover .info:last-child, ol#itemListMovies li:hover .tagList { display: block !important; }');
+            gmAddStyle('ol#itemListToplists li:hover .info:last-child, ol#itemListMovies li:hover .tagList { display: block !important; }');
         }
     }
 };
 
-ICM_HideTags.prototype.settings = {
+HideTags.prototype.settings = {
     title: 'Hide tags',
     desc: 'Hides tags on individual lists',
     index: 'hide_tags',
@@ -1277,14 +1284,14 @@ ICM_HideTags.prototype.settings = {
 };
 
 // Inherit methods from BaseFeature
-ICM_WatchlistTab.prototype = Object.create(ICM_BaseFeature.prototype);
-ICM_WatchlistTab.prototype.constructor = ICM_WatchlistTab;
+WatchlistTab.prototype = Object.create(BaseFeature.prototype);
+WatchlistTab.prototype.constructor = WatchlistTab;
 
-function ICM_WatchlistTab(config) {
-    ICM_BaseFeature.call(this, config);
+function WatchlistTab(config) {
+    BaseFeature.call(this, config);
 }
 
-ICM_WatchlistTab.prototype.Attach = function() {
+WatchlistTab.prototype.attach = function() {
     if (!this.config.enabled) {
         return;
     }
@@ -1294,10 +1301,10 @@ ICM_WatchlistTab.prototype.Attach = function() {
         return;
     }
 
-    var watch_count = $movies.children('li.watch').length;
+    var watchCount = $movies.children('li.watch').length;
     var tabHtml = '<li id="listFilterWatch" class="topListMoviesFilter">' +
         '<a id="linkListFilterWatch" href="#" title="View all your watchlist movies">Watchlist ' +
-        '<span id="topListMoviesWatchCount">(' + watch_count + ')</span></a>' +
+        '<span id="topListMoviesWatchCount">(' + watchCount + ')</span></a>' +
         '</li>';
 
     $('#listFilterUnchecked').after(tabHtml);
@@ -1324,7 +1331,7 @@ ICM_WatchlistTab.prototype.Attach = function() {
     });
 };
 
-ICM_WatchlistTab.prototype.settings = {
+WatchlistTab.prototype.settings = {
     title: 'Watchlist tab',
     desc: 'Creates a tab on lists that shows watchlist entries.',
     index: 'watchlist_tab',
@@ -1339,14 +1346,14 @@ ICM_WatchlistTab.prototype.settings = {
 };
 
 // Inherit methods from BaseFeature
-ICM_Owned.prototype = Object.create(ICM_BaseFeature.prototype);
-ICM_Owned.prototype.constructor = ICM_Owned;
+Owned.prototype = Object.create(BaseFeature.prototype);
+Owned.prototype.constructor = Owned;
 
-function ICM_Owned(config) {
-    ICM_BaseFeature.call(this, config);
+function Owned(config) {
+    BaseFeature.call(this, config);
 }
 
-ICM_Owned.prototype.Attach = function() {
+Owned.prototype.attach = function() {
     if (!this.config.enabled) {
         return;
     }
@@ -1359,15 +1366,15 @@ ICM_Owned.prototype.Attach = function() {
     }
 
     if (this.config.free_account) {
-        var owned = evalOrParse(GM_getValue('owned_movies', '[]')),
+        var owned = evalOrParse(gmGetValue('owned_movies', '[]')),
             onListPage = $movielist.length !== 0;
 
         // mark owned movies as owned
         $markOwned.each(function() {
             var $checkbox = $(this).closest('.optionIconMenu').prev('.checkbox'),
                 $movie = $checkbox.parent(),
-                movie_id = $checkbox.attr('id').replace('check', 'movie'),
-                ind = owned.indexOf(movie_id);
+                movieId = $checkbox.attr('id').replace('check', 'movie'),
+                ind = owned.indexOf(movieId);
 
             // if movie id is found in cached owned movies
             if (ind !== -1) {
@@ -1379,37 +1386,37 @@ ICM_Owned.prototype.Attach = function() {
         });
 
         $('.optionMarkOwned').on('click', function() {
-            owned = evalOrParse(GM_getValue('owned_movies', '[]'));
+            owned = evalOrParse(gmGetValue('owned_movies', '[]'));
 
             var $checkbox = $(this).closest('.optionIconMenu').prev('.checkbox'),
                 $movie = $checkbox.parent(),
-                movie_id = $checkbox.attr('id').replace('check', 'movie'),
-                ind = owned.indexOf(movie_id);
+                movieId = $checkbox.attr('id').replace('check', 'movie'),
+                ind = owned.indexOf(movieId);
 
             // if movie id is found in cached owned movies
-            console.log((ind !== -1 ? 'removing' : 'storing') + ' ' + movie_id);
+            console.log((ind !== -1 ? 'removing' : 'storing') + ' ' + movieId);
             if (ind !== -1) {
                 owned.splice(ind, 1);
             } else {
-                owned.push(movie_id);
+                owned.push(movieId);
             }
             $movie.toggleClass('notowned owned');
 
             if (onListPage) {
-                var owned_count = $movielist.children('li.owned').length;
-                $('#topListMoviesOwnedCount').text('(' + owned_count + ')');
+                var ownedCount = $movielist.children('li.owned').length;
+                $('#topListMoviesOwnedCount').text('(' + ownedCount + ')');
             }
 
-            GM_setValue('owned_movies', JSON.stringify(owned));
+            gmSetValue('owned_movies', JSON.stringify(owned));
 
             return false;
         });
     }
 
-    var owned_count = $movielist.children('li.owned').length;
+    var ownedCount = $movielist.children('li.owned').length;
     var tabHtml = '<li id="listFilterOwned" class="topListMoviesFilter">' +
         '<a id="linkListFilterOwned" href="#" title="View all your owned movies">Owned ' +
-        '<span id="topListMoviesOwnedCount">(' + owned_count + ')</span></a>' + '</li>';
+        '<span id="topListMoviesOwnedCount">(' + ownedCount + ')</span></a>' + '</li>';
 
     $('#listFilterNew').before(tabHtml);
 
@@ -1435,7 +1442,7 @@ ICM_Owned.prototype.Attach = function() {
     });
 };
 
-ICM_Owned.prototype.settings = {
+Owned.prototype.settings = {
     title: 'Owned tab',
     desc: 'Creates a tab on lists that shows owned entries. Emulates the paid feature',
     index: 'owned_tab',
@@ -1455,16 +1462,16 @@ ICM_Owned.prototype.settings = {
 };
 
 // Inherit methods from BaseFeature
-ICM_LargeList.prototype = Object.create(ICM_BaseFeature.prototype);
-ICM_LargeList.prototype.constructor = ICM_LargeList;
+LargeList.prototype = Object.create(BaseFeature.prototype);
+LargeList.prototype.constructor = LargeList;
 
-function ICM_LargeList(config) {
-    ICM_BaseFeature.call(this, config);
+function LargeList(config) {
+    BaseFeature.call(this, config);
 
     this.loaded = false;
 }
 
-ICM_LargeList.prototype.Attach = function() {
+LargeList.prototype.attach = function() {
     if (!this.config.enabled) {
         return;
     }
@@ -1496,7 +1503,7 @@ ICM_LargeList.prototype.Attach = function() {
     }
 };
 
-ICM_LargeList.prototype.load = function() {
+LargeList.prototype.load = function() {
     if (this.loaded) {
         return;
     }
@@ -1516,7 +1523,7 @@ ICM_LargeList.prototype.load = function() {
         '#itemListMovies .optionIconMenu li { display: block !important }' +
         '#itemListMovies .optionIconMenuCheckbox { right:20px !important }';
 
-    GM_addStyle(style);
+    gmAddStyle(style);
 
     var $c = $('#itemListMovies').find('div.coverImage').hide();
     for (var i = 0; i < $c.length; i++) {
@@ -1536,7 +1543,7 @@ ICM_LargeList.prototype.load = function() {
     $('img.coverImage').lazyload({ threshold: 200 });
 };
 
-ICM_LargeList.prototype.settings = {
+LargeList.prototype.settings = {
     title: 'Large posters',
     desc: 'Display large posters on individual lists (large posters are lazy loaded)',
     index: 'large_lists',
@@ -1558,63 +1565,63 @@ ICM_LargeList.prototype.settings = {
 };
 
 // Inherit methods from BaseFeature
-ICM_ListOverviewSort.prototype = Object.create(ICM_BaseFeature.prototype);
-ICM_ListOverviewSort.prototype.constructor = ICM_ListOverviewSort;
+ListOverviewSort.prototype = Object.create(BaseFeature.prototype);
+ListOverviewSort.prototype.constructor = ListOverviewSort;
 
-function ICM_ListOverviewSort(config) {
-    ICM_BaseFeature.call(this, config);
+function ListOverviewSort(config) {
+    BaseFeature.call(this, config);
 }
 
-ICM_ListOverviewSort.prototype.Attach = function() {
+ListOverviewSort.prototype.attach = function() {
     if (!this.config.enabled) {
         return;
     }
 
     if ( this.config.single_col ) {
-        GM_addStyle('.itemList .listItem.listItemProgress { float: none !important; }');
+        gmAddStyle('.itemList .listItem.listItemProgress { float: none !important; }');
     }
 
     var order = this.config.order === true ? 'desc' : 'asc';
-    this.Rearrange(order, 'all');
+    this.rearrange(order, 'all');
 
     var _t = this;
     $('#progressFilter a').not('#progressFilter-all').one('click', function() {
         var section = $(this).attr('id').split('-')[1];
-        _t.Rearrange(order, section);
+        _t.rearrange(order, section);
     });
 };
 
-ICM_ListOverviewSort.prototype.Rearrange = function(order, section) {
-    var $toplist_list = $('#progress' + section),
-        $toplist_items = $toplist_list.children('li').detach(),
+ListOverviewSort.prototype.rearrange = function(order, section) {
+    var $toplistList = $('#progress' + section),
+        $toplistItems = $toplistList.children('li').detach(),
         isInterweaved = true;
 
     if ( this.config.hide_imdb && section === 'all') {
         if (this.config.autosort) {
-            $toplist_items = $toplist_items.not('.imdb');
+            $toplistItems = $toplistItems.not('.imdb');
             // list would be sorted anyway, but until then the order is incorrect
         } else {
             // preserve original order
-            $toplist_items = $(this.Straighten($toplist_items.toArray())).not('.imdb');
+            $toplistItems = $(this.straighten($toplistItems.toArray())).not('.imdb');
             isInterweaved = false;
         }
     }
 
-    var toplist_arr = $toplist_items.toArray();
+    var toplistArr = $toplistItems.toArray();
 
     if (this.config.autosort) {
-        var lookup_map = toplist_arr.map(function(item, i) {
+        var lookupMap = toplistArr.map(function(item, i) {
             var width = $(item).find('span.progress').css('width').replace('px', '');
             return {index: i, value: parseFloat(width)};
         });
 
-        lookup_map.sort(function(a, b) {
+        lookupMap.sort(function(a, b) {
             return (order === 'asc' ? 1 : -1) *
                 (a.value > b.value ? 1 : -1);
         });
 
-        toplist_arr = lookup_map.map(function(e) {
-            return toplist_arr[e.index];
+        toplistArr = lookupMap.map(function(e) {
+            return toplistArr[e.index];
         });
 
         isInterweaved = false;
@@ -1624,38 +1631,38 @@ ICM_ListOverviewSort.prototype.Rearrange = function(order, section) {
     var verticalOrder = this.config.icebergs || this.config.single_col;
     if (!isInterweaved && !verticalOrder) {
         // restore default two-column view after sorting/hiding
-        toplist_arr = this.Interweave(toplist_arr);
+        toplistArr = this.interweave(toplistArr);
     }
     if (isInterweaved && verticalOrder) {
         // no sorting/hiding happened; rearrange the list with original order
-        toplist_arr = this.Straighten(toplist_arr);
+        toplistArr = this.straighten(toplistArr);
     }
-    $toplist_list.append(toplist_arr);
+    $toplistList.append(toplistArr);
 };
 
 // [1, 'a', 2, 'b', 3, 'c']    -> [1, 2, 3, 'a', 'b', 'c']
 // [1, 'a', 2, 'b', 3, 'c', 4] -> [1, 2, 3, 4, 'a', 'b', 'c']
-ICM_ListOverviewSort.prototype.Straighten = function(list) {
-    var even_i = [], odd_i = [];
+ListOverviewSort.prototype.straighten = function(list) {
+    var even = [], odd = [];
     for (var i = 0; i < list.length; i++) {
         if (i % 2 === 0) {
-            even_i.push(list[i]);
+            even.push(list[i]);
         } else {
-            odd_i.push(list[i]);
+            odd.push(list[i]);
         }
     }
-    return $.merge(even_i, odd_i);
+    return $.merge(even, odd);
 };
 
 // [1, 2, 3, 'a', 'b', 'c']    -> [1, 'a', 2, 'b', 3, 'c']
 // [1, 2, 3, 4, 'a', 'b', 'c'] -> [1, 'a', 2, 'b', 3, 'c', 4]
-ICM_ListOverviewSort.prototype.Interweave = function(list) {
+ListOverviewSort.prototype.interweave = function(list) {
     var res = [],
-        half_len = Math.ceil(list.length / 2);
-    for (var i = 0; i < half_len; i++) {
+        halfLen = Math.ceil(list.length / 2);
+    for (var i = 0; i < halfLen; i++) {
         res.push(list[i]);
-        if (i + half_len < list.length) {
-            res.push(list[i + half_len]);
+        if (i + halfLen < list.length) {
+            res.push(list[i + halfLen]);
         }
     }
     return res;
@@ -1669,7 +1676,7 @@ function test(arr) {
 }
 test(a) && test(b) */
 
-ICM_ListOverviewSort.prototype.settings = {
+ListOverviewSort.prototype.settings = {
     title: 'Progress page',
     desc: 'Change the order of lists on the progress page',
     index: 'toplists_sort',
@@ -1709,11 +1716,11 @@ ICM_ListOverviewSort.prototype.settings = {
 };
 
 // Inherit methods from BaseFeature
-ICM_ListsTabDisplay.prototype = Object.create(ICM_BaseFeature.prototype);
-ICM_ListsTabDisplay.prototype.constructor = ICM_ListsTabDisplay;
+ListsTabDisplay.prototype = Object.create(BaseFeature.prototype);
+ListsTabDisplay.prototype.constructor = ListsTabDisplay;
 
-function ICM_ListsTabDisplay(config) {
-    ICM_BaseFeature.call(this, config);
+function ListsTabDisplay(config) {
+    BaseFeature.call(this, config);
 
     this.block = $('#itemListToplists');
     this.sep = '<li class="groupSeparator"><br><hr><br></li>';
@@ -1721,7 +1728,7 @@ function ICM_ListsTabDisplay(config) {
     this.reURL = /^[ \t]*(?:https?:\/\/)?(?:www\.)?(?:icheckmovies.com)?\/?(?:lists)?\/?([^\s\?]+\/)(?:\?.+)?[ \t]*$/gm;
 }
 
-ICM_ListsTabDisplay.prototype.Attach = function() {
+ListsTabDisplay.prototype.attach = function() {
     var isOnMoviePage = (new RegExp( this.settings.includes[2] )).test(window.location.href),
         _c = this.config;
 
@@ -1744,10 +1751,10 @@ ICM_ListsTabDisplay.prototype.Attach = function() {
                 var stored = _c[group];
                 if (typeof stored === 'string') {
                     // Parse textarea content
-                    console.log('Parsing ICM_ListsTabDisplay group', group);
+                    console.log('Parsing ListsTabDisplay group', group);
                     stored = stored.trim().replace(_t.reURL, '$1').split('\n');
                     _c[group] = stored;
-                    _t.globalConfig.Save();
+                    _t.globalConfig.save();
                 }
                 var personal = _t.getLists(stored);
                 _t.move(personal);
@@ -1774,7 +1781,7 @@ ICM_ListsTabDisplay.prototype.Attach = function() {
     }
 };
 
-ICM_ListsTabDisplay.prototype.move = function(lists) {
+ListsTabDisplay.prototype.move = function(lists) {
     if (lists.length) {
         var target = this.block.find('li.groupSeparator').last();
         if (target.length) {
@@ -1785,7 +1792,7 @@ ICM_ListsTabDisplay.prototype.move = function(lists) {
     }
 };
 
-ICM_ListsTabDisplay.prototype.getLists = function(listIDs) {
+ListsTabDisplay.prototype.getLists = function(listIDs) {
     if (listIDs.length) {
         var selected = this.block.children().filter(function() {
             var href = $(this).find('a.title').attr('href');
@@ -1796,7 +1803,7 @@ ICM_ListsTabDisplay.prototype.getLists = function(listIDs) {
     return [];
 };
 
-ICM_ListsTabDisplay.prototype.settings = {
+ListsTabDisplay.prototype.settings = {
     title: 'Lists tab display',
     desc: 'Organize movie info tab with all lists (\/movies\/*\/rankings\/, <a href="/movies/pulp+fiction/rankings/">example</a>)',
     index: 'lists_tab_display',
@@ -1840,14 +1847,14 @@ ICM_ListsTabDisplay.prototype.settings = {
 };
 
 // Inherit methods from BaseFeature
-ICM_ExportLists.prototype = Object.create(ICM_BaseFeature.prototype);
-ICM_ExportLists.prototype.constructor = ICM_ExportLists;
+ExportLists.prototype = Object.create(BaseFeature.prototype);
+ExportLists.prototype.constructor = ExportLists;
 
-function ICM_ExportLists(config) {
-    ICM_BaseFeature.call(this, config);
+function ExportLists(config) {
+    BaseFeature.call(this, config);
 }
 
-ICM_ExportLists.prototype.Attach = function() {
+ExportLists.prototype.attach = function() {
     var _c = this.config;
     if (!_c.enabled) {
         return;
@@ -1863,7 +1870,7 @@ ICM_ExportLists.prototype.Attach = function() {
         var data =  ['rank', 'title', 'aka', 'year', 'official_toplists',
             'checked', 'favorite', 'dislike', 'imdb'].join(sep) + sep + '\n';
 
-        var encode_field = function(field) {
+        var encodeField = function(field) {
             return field.indexOf('"') !== -1 || field.indexOf(sep) !== -1 ?
                    '"' + field.replace('"', '""', 'g') + '"' :
                    field;
@@ -1872,8 +1879,8 @@ ICM_ExportLists.prototype.Attach = function() {
         $('#itemListMovies > li').each(function() {
             var item = $(this),
                 rank = item.find('.rank').text().trim().replace(/ .+/, ''),
-                title = encode_field(item.find('h2>a').text()),
-                aka = encode_field(item.find('.info > em').text()),
+                title = encodeField(item.find('h2>a').text()),
+                aka = encodeField(item.find('.info > em').text()),
                 year = item.find('.info a:first').text(),
                 toplists = parseInt(item.find('.info a:last').text(), 10),
                 checked = item.hasClass('checked') ? 'yes' : 'no',
@@ -1898,7 +1905,7 @@ ICM_ExportLists.prototype.Attach = function() {
     });
 };
 
-ICM_ExportLists.prototype.settings = {
+ExportLists.prototype.settings = {
     title: 'Export lists',
     desc: 'Download any list as .csv (doesn\'t support search results). Emulates the paid feature, so don\'t enable it if you have a paid account',
     index: 'export_lists',
@@ -1923,14 +1930,14 @@ ICM_ExportLists.prototype.settings = {
 };
 
 // Inherit methods from BaseFeature
-ICM_ProgressTopX.prototype = Object.create(ICM_BaseFeature.prototype);
-ICM_ProgressTopX.prototype.constructor = ICM_ProgressTopX;
+ProgressTopX.prototype = Object.create(BaseFeature.prototype);
+ProgressTopX.prototype.constructor = ProgressTopX;
 
-function ICM_ProgressTopX(config) {
-    ICM_BaseFeature.call(this, config);
+function ProgressTopX(config) {
+    BaseFeature.call(this, config);
 }
 
-ICM_ProgressTopX.prototype.Attach = function() {
+ProgressTopX.prototype.attach = function() {
     if (this.config.enabled) {
         var css = 'float: left; margin-right: 0.5em',
             attr = {text: 'Load stats', id: 'icme_req_for_top', href: '#', style: css},
@@ -1942,7 +1949,7 @@ ICM_ProgressTopX.prototype.Attach = function() {
     }
 };
 
-ICM_ProgressTopX.prototype.addStats = function(event) {
+ProgressTopX.prototype.addStats = function(event) {
     var targetPage = parseInt(event.data.cfg.target_page, 10), // * 25 = target rank
         lists = $('.itemListCompact[id^="progress"]:visible span.rank a');
 
@@ -1972,7 +1979,7 @@ ICM_ProgressTopX.prototype.addStats = function(event) {
     return false; // prevents auto-scrolling to the top
 };
 
-ICM_ProgressTopX.prototype.settings = {
+ProgressTopX.prototype.settings = {
     title: 'Progress top X',
     desc: 'Find out how many checks you need to get into Top 25/50/100/1000/...',
     index: 'progress_top_x',
@@ -1995,47 +2002,47 @@ ICM_ProgressTopX.prototype.settings = {
  * Main application
  * Register and load modules
  */
-function ICM_Enhanced(scriptConfig) {
+function Enhanced(scriptConfig) {
     this.modules = [];
-    this.configWindow = new ICM_ConfigWindow(scriptConfig);
+    this.configWindow = new ConfigWindow(scriptConfig);
 }
 
-ICM_Enhanced.prototype.register = function(module) {
+Enhanced.prototype.register = function(module) {
     this.modules.push(module);
     this.configWindow.addModule(module.settings);
 };
 
-ICM_Enhanced.prototype.load = function() {
+Enhanced.prototype.load = function() {
     $.each(this.modules, function(i, m) {
-        if (m.IsEnabled()) {
+        if (m.isEnabled()) {
             console.log('Attaching ' + m.constructor.name);
-            m.Attach();
+            m.attach();
         }
     });
 
     this.configWindow.build();
 };
 
-var config = new ICM_Config();
+var config = new Config();
 // console.log("Loaded config", config); // debug
 
 var useModules = [
-    ICM_RandomFilmLink,
-    ICM_HideTags,
-    ICM_UpcomingAwardsList,
-    ICM_ListCustomColors,
-    ICM_UpcomingAwardsOverview,
-    ICM_ListCrossCheck,
-    ICM_WatchlistTab,
-    ICM_Owned,
-    ICM_LargeList,
-    ICM_ListOverviewSort,
-    ICM_ListsTabDisplay,
-    ICM_ExportLists,
-    ICM_ProgressTopX
+    RandomFilmLink,
+    HideTags,
+    UpcomingAwardsList,
+    ListCustomColors,
+    UpcomingAwardsOverview,
+    ListCrossCheck,
+    WatchlistTab,
+    Owned,
+    LargeList,
+    ListOverviewSort,
+    ListsTabDisplay,
+    ExportLists,
+    ProgressTopX
 ];
 
-var app = new ICM_Enhanced(config);
+var app = new Enhanced(config);
 $.each(useModules, function(i, Obj) {
     app.register(new Obj(config));
 });

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -145,27 +145,27 @@ Config.prototype.init = function() {
 // Save config
 Config.prototype.save = function() {
     // console.log("Saving config", this.cfg); // debug
-    gmSetValue( 'icm_enhanced_cfg', JSON.stringify(this.cfg));
+    gmSetValue('icm_enhanced_cfg', JSON.stringify(this.cfg));
 };
 
 // Get config value
-Config.prototype.get = function( index ) {
+Config.prototype.get = function(index) {
     return getProperty(index, this.cfg);
 };
 
 // Set config value
-Config.prototype.set = function( index, value ) {
+Config.prototype.set = function(index, value) {
     setProperty(index, this.cfg, value);
 };
 
 // Sets false to true and vice versa
-Config.prototype.toggle = function( index ) {
+Config.prototype.toggle = function(index) {
     var val = this.get(index),
         changeVal;
 
-    if ( val === true || val === false ) {
+    if (val === true || val === false) {
         changeVal = !val;
-    } else if ( val === 'asc' || val === 'desc' ) {
+    } else if (val === 'asc' || val === 'desc') {
         changeVal = val === 'asc' ? 'desc' : 'asc';
     } else {
         return false; // Couldn't toggle a value
@@ -252,7 +252,7 @@ ConfigWindow.prototype.build = function() {
     var cfgLink = '<li><a id="icm_enhanced_cfg" href="#"' +
         'title="Configure iCheckMovies Enhanced script options">ICM Enhanced</a></li>';
 
-    $('ul#profileOptions').append( cfgLink );
+    $('ul#profileOptions').append(cfgLink);
 
     // Custom CSS for jqmodal
     var customCSS =
@@ -297,20 +297,20 @@ ConfigWindow.prototype.build = function() {
 
     var _t = this;
 
-    $('div#cfgModal').on( 'change', 'input, textarea', function() {
+    $('div#cfgModal').on('change', 'input, textarea', function() {
         var index = $(this).data('cfg-index');
         if (index === undefined) {
             return;
         }
 
-        if ( !_t.config.toggle(index) ) {
-            _t.config.set( index, $(this).val() );
+        if (!_t.config.toggle(index)) {
+            _t.config.set(index, $(this).val());
         }
 
         $('button#configSave').prop('disabled', false);
     });
 
-    $('div#cfgModal').on( 'click', 'button#configSave', function() {
+    $('div#cfgModal').on('click', 'button#configSave', function() {
         _t.config.save();
 
         $(this).prop('disabled', true);
@@ -324,7 +324,7 @@ ConfigWindow.prototype.build = function() {
     $('#modulelist').trigger('change');
 
     // initialize config window
-    $('#cfgModal').jqm( { trigger: 'a#icm_enhanced_cfg' } );
+    $('#cfgModal').jqm({ trigger: 'a#icm_enhanced_cfg' });
 
     // Initialize spectrum plugin
     gmAddStyle(gmGetResourceText('spectrumCss'));
@@ -342,7 +342,7 @@ function RandomFilmLink(config) {
 
 // Creates an element and inserts it into the DOM
 RandomFilmLink.prototype.attach = function() {
-    if ( !this.config.enabled ) {
+    if (!this.config.enabled) {
         return;
     }
 
@@ -350,19 +350,19 @@ RandomFilmLink.prototype.attach = function() {
         '<span style="float:right; margin-left: 15px">' +
             '<a href="#" id="randomFilm">Help me pick a film!</a></span>';
 
-    if ( $('div#list_container').length !== 1 ) {
+    if ($('div#list_container').length !== 1) {
         var container =
             '<div id="list_container" style="height: 35px; position: relative">' +
                 randomFilm + '</div>';
 
-        $('#movies').parent().before( container );
+        $('#movies').parent().before(container);
     } else {
-        $('div#list_container').append( randomFilm );
+        $('div#list_container').append(randomFilm);
     }
 
     var that = this;
 
-    $('div#list_container').on( 'click', 'a#randomFilm', function(e) {
+    $('div#list_container').on('click', 'a#randomFilm', function(e) {
         e.preventDefault();
 
         that.pickRandomFilm();
@@ -374,29 +374,29 @@ RandomFilmLink.prototype.pickRandomFilm = function() {
     var $unchecked = $('ol#itemListMovies > li.unchecked'),
         randNum;
 
-    if ( !$unchecked.length ) {
+    if (!$unchecked.length) {
         return;
     }
 
-    if ( this.config.unique ) {
+    if (this.config.unique) {
         // Generate random numbers
-        if ( !this.randomNums.length ) {
+        if (!this.randomNums.length) {
             // Populate randomNums
-            for ( var i = 0; i < $unchecked.length; i++ ) {
-                this.randomNums.push( i );
+            for (var i = 0; i < $unchecked.length; i++) {
+                this.randomNums.push(i);
             }
 
             // Shuffle the results for randomness in-place
-            shuffle( this.randomNums );
+            shuffle(this.randomNums);
         }
 
         randNum = this.randomNums.pop();
     } else {
-        randNum = Math.floor( Math.random() * $unchecked.length );
+        randNum = Math.floor(Math.random() * $unchecked.length);
     }
 
     $('ol#itemListMovies > li').hide();
-    $( $unchecked[ randNum ] ).show();
+    $($unchecked[ randNum ]).show();
 };
 
 RandomFilmLink.prototype.settings = {
@@ -428,7 +428,7 @@ function UpcomingAwardsList(config) {
 }
 
 UpcomingAwardsList.prototype.attach = function() {
-    if ( !this.config.enabled || !$('#itemListMovies').length ) {
+    if (!this.config.enabled || !$('#itemListMovies').length) {
         return;
     }
 
@@ -448,14 +448,14 @@ UpcomingAwardsList.prototype.attach = function() {
     statistics += getSpan('Bronze', 0.5) + getSpan('Silver', 0.75) +
                   getSpan('Gold', 0.9) + getSpan('Platinum', 1);
 
-    if ( $('div#list_container').length !== 1 ) {
+    if ($('div#list_container').length !== 1) {
         var container =
             '<div id="list_container" style="height: 35px; position: relative">' +
                 statistics + '</div>';
 
-        $('#movies').parent().before( container );
+        $('#movies').parent().before(container);
     } else {
-        $('div#list_container').append( statistics );
+        $('div#list_container').append(statistics);
     }
 };
 
@@ -490,10 +490,10 @@ function UpcomingAwardsOverview(config) {
 }
 
 UpcomingAwardsOverview.prototype.attach = function() {
-    if ( !this.config.enabled ) {
+    if (!this.config.enabled) {
         return;
     }
-    if ( this.config.autoload ) {
+    if (this.config.autoload) {
         this.loadAwardData();
         return;
     }
@@ -506,7 +506,7 @@ UpcomingAwardsOverview.prototype.attach = function() {
     var that = this;
     $('p#lad_container').on('click', 'a#load_award_data', function(e) {
         e.preventDefault();
-        $( e.target ).remove();
+        $(e.target).remove();
         that.loadAwardData();
     });
 };
@@ -538,8 +538,8 @@ UpcomingAwardsOverview.prototype.populateLists = function() {
             return;
         }
 
-        var checks     = parseInt( countArr[0], 10 ),
-            totalItems = parseInt( countArr[1], 10 ),
+        var checks     = parseInt(countArr[0], 10),
+            totalItems = parseInt(countArr[1], 10),
             $t         = $el.find(curSel.title),
             listTitle  = $t.attr('title').replace(/^View the | top list$/g, ''),
             listUrl    = $t.attr('href');
@@ -799,7 +799,7 @@ function ListCustomColors(config) {
 }
 
 ListCustomColors.prototype.attach = function() {
-    if ( this.config.enabled ) {
+    if (this.config.enabled) {
         var listColorsCss = '';
 
         var buildCSS = function(className, color) {
@@ -893,7 +893,7 @@ ListCrossCheck.prototype.attach = function() {
     $('#itemContainer').before(actions);
     var _t = this;
 
-    $('div#crActions').on( 'click', 'button#cfgListCCActivate', function() {
+    $('div#crActions').on('click', 'button#cfgListCCActivate', function() {
         $(this).prop('disabled', true);
         _t.createTab();
         _t.activate();
@@ -931,26 +931,26 @@ ListCrossCheck.prototype.activate = function() {
 
     $('ol#itemListToplists li').on('click mouseover mouseout', function(e) {
         var activeAndIdle = _t.activated && !_t.inProgress;
-        if ( !activeAndIdle ) { // ff 3.6 compatibility
+        if (!activeAndIdle) { // ff 3.6 compatibility
             return;
         }
 
         var li = $(this);
         // event actions must not work for cloned toplists under the selected tab
-        if ( li.hasClass('icme_listcc') ) {
+        if (li.hasClass('icme_listcc')) {
             return false; // ff 3.6 compatibility
         }
 
         var wasSelected = li.hasClass('icme_listcc_selected');
-        if ( e.type === 'mouseover' && !wasSelected ) {
+        if (e.type === 'mouseover' && !wasSelected) {
             li.addClass('icme_listcc_hover').find('span.percentage').hide();
-        } else if ( e.type === 'mouseout' && !wasSelected ) {
+        } else if (e.type === 'mouseout' && !wasSelected) {
             li.removeClass('icme_listcc_hover').find('span.percentage').show();
-        } else if ( e.type === 'click' ) {
+        } else if (e.type === 'click') {
             li.removeClass('icme_listcc_hover');
             li.toggleClass('icme_listcc_selected');
 
-            if ( wasSelected ) { // before click
+            if (wasSelected) { // before click
                 li.addClass('icme_listcc_hover');
             }
         }
@@ -1029,7 +1029,7 @@ ListCrossCheck.prototype.getUncheckedFilms = function(listElem) {
         // the site returns html with extra whitespace
         var unchecked = $($.parseHTML(response)).find('ol#itemListMovies').children(filter);
 
-        _t.updateMovies( unchecked );
+        _t.updateMovies(unchecked);
     });
 };
 
@@ -1058,11 +1058,11 @@ ListCrossCheck.prototype.updateMovies = function(content) {
             movieUrl = curTitle.find('a').attr('href'),
             movieYear = curTitle.next('span.info').children('a:first').text();
 
-        for ( var j = 0; j < this.movies.length; j++ ) {
+        for (var j = 0; j < this.movies.length; j++) {
             // compare urls as they're guaranteed to be unique
             // in some cases movie title and release year are the same for different movies
             // which results in incorrect top list values
-            if ( movieUrl === this.movies[j].u ) {
+            if (movieUrl === this.movies[j].u) {
                 this.movies[j].c += 1;
 
                 this.movies[j].jq.find('.rank').html(this.movies[j].c);
@@ -1079,7 +1079,7 @@ ListCrossCheck.prototype.updateMovies = function(content) {
         //   only if the script is not checking for matches on all top lists
         //     OR if the script is     checking for matches on all top lists,
         //        but this is just the first top list
-        if ( !found && ( !showPerfectMatches || this.sequenceNumber === 1 ) ) {
+        if (!found && (!showPerfectMatches || this.sequenceNumber === 1)) {
             var $item = $(content[i]);
             $item.find('.rank').html('0');
 
@@ -1092,32 +1092,32 @@ ListCrossCheck.prototype.updateMovies = function(content) {
             }
 
             // t = title, c = count, u = url, y = year
-            this.movies.push( {t: movie, c: 1, u: movieUrl, y: movieYear, jq: $item} );
+            this.movies.push({t: movie, c: 1, u: movieUrl, y: movieYear, jq: $item});
         }
     }
 
     var hasToplistsLeft = this.sequenceNumber < this.toplists.length;
 
     // if finding movies on all selected top lists
-    if ( showPerfectMatches ) {
+    if (showPerfectMatches) {
         // if one or more movies was found on all selected top lists
-        if ( globalToplistMatch ) {
+        if (globalToplistMatch) {
             // if not first top list, extract movies that have been found on all selected top lists
-            if ( this.sequenceNumber > 1 ) {
+            if (this.sequenceNumber > 1) {
                 var cutoff = this.sequenceNumber;
                 this.movies = $.grep(this.movies, function(el) {
                     return el.c === cutoff;
                 });
             }
         // if didn't find a single match, abort if it's the last or not the first top list
-        } else if ( this.sequenceNumber > 1 || !hasToplistsLeft ) {
+        } else if (this.sequenceNumber > 1 || !hasToplistsLeft) {
             this.movies = [];
             hasToplistsLeft = false; // force output
         }
     }
 
     // if there's still more top lists
-    if ( hasToplistsLeft ) {
+    if (hasToplistsLeft) {
         this.getUncheckedFilms(this.toplists[this.sequenceNumber]);
     } else {
         this.outputMovies();
@@ -1127,10 +1127,10 @@ ListCrossCheck.prototype.updateMovies = function(content) {
 ListCrossCheck.prototype.outputMovies = function() {
     var showPerfectMatches = this.config.match_all;
 
-    if ( !showPerfectMatches ) {
+    if (!showPerfectMatches) {
         var limit = this.config.match_min;
 
-        if ( limit > 0 ) {
+        if (limit > 0) {
             this.movies = $.grep(this.movies, function(el) {
                 return el.c >= limit;
             });
@@ -1155,7 +1155,7 @@ ListCrossCheck.prototype.outputMovies = function() {
         return 0;
     });
 
-    if ( this.movies.length > 0 ) {
+    if (this.movies.length > 0) {
         var menu = '<ul>';
         for (var i = 0; i < this.toplists.length; ++i) {
             menu += '<li><b>' + $(this.toplists[i]).find('h2').text() + '</b></li>';
@@ -1236,7 +1236,7 @@ ListCrossCheck.prototype.createTab = function() {
         '<strong style="display: none">Cross-reference</strong></li>';
 
     var $tlfilter = $('ul.tabMenu', 'div#itemContainer');
-    $tlfilter.append( tab );
+    $tlfilter.append(tab);
 
     var _t = this;
 
@@ -1249,7 +1249,7 @@ ListCrossCheck.prototype.createTab = function() {
         });
         b.addClass('active');
 
-        if ( a === 'icme_listcc' && !_t.inProgress ) {
+        if (a === 'icme_listcc' && !_t.inProgress) {
             var $topListUl = $('ol#itemListToplists');
             $topListUl.children('li.icme_listcc').remove();
 
@@ -1259,10 +1259,10 @@ ListCrossCheck.prototype.createTab = function() {
                 .removeClass('imdb critics prizes website institute misc icme_listcc_selected')
                 .addClass('icme_listcc').find('span.percentage').show();
 
-            $topListUl.append( $topLists );
+            $topListUl.append($topLists);
 
             var selectedTwoOrMore = $('li.icme_listcc', 'ol#itemListToplists').length >= 2;
-            if ( selectedTwoOrMore && $('button#icme_listcc_check').length === 0 ) {
+            if (selectedTwoOrMore && $('button#icme_listcc_check').length === 0) {
                 var btn = '<button id="icme_listcc_check">Cross-reference</button>';
 
                 $('div#crActions').append(btn);
@@ -1285,7 +1285,7 @@ ListCrossCheck.prototype.createTab = function() {
                         });
                     }
                 });
-            } else if ( !selectedTwoOrMore && $('button#icme_listcc_check').length === 1 ) {
+            } else if (!selectedTwoOrMore && $('button#icme_listcc_check').length === 1) {
                 $('button#icme_listcc_check').remove();
             }
         }
@@ -1574,16 +1574,16 @@ LargeList.prototype.attach = function() {
     var link = '<span style="float: right; margin-left: 15px">' +
         '<a id="icme_large_posters" href="#">Large posters</a></span>';
 
-    if ( $('div#list_container').length !== 1 ) {
+    if ($('div#list_container').length !== 1) {
         var container = '<div id="list_container" style="height: 35px; ' +
             'position: relative">' + link + '</div>';
 
-        $('#movies').parent().before( container );
+        $('#movies').parent().before(container);
     } else {
         if ($('#list_container').find('p').length === 1) {
             $('#list_container p:first').append('<span> &mdash; </span>' + link);
         } else {
-            $('div#list_container').append( link );
+            $('div#list_container').append(link);
         }
     }
 
@@ -1688,7 +1688,7 @@ ListOverviewSort.prototype.attach = function() {
         return;
     }
 
-    if ( this.config.single_col ) {
+    if (this.config.single_col) {
         gmAddStyle('.itemList .listItem.listItemProgress { float: none !important; }');
     }
 
@@ -1707,7 +1707,7 @@ ListOverviewSort.prototype.rearrange = function(order, section) {
         $toplistItems = $toplistList.children('li').detach(),
         isInterweaved = true;
 
-    if ( this.config.hide_imdb && section === 'all') {
+    if (this.config.hide_imdb && section === 'all') {
         if (this.config.autosort) {
             $toplistItems = $toplistItems.not('.imdb');
             // list would be sorted anyway, but until then the order is incorrect
@@ -1840,7 +1840,7 @@ function ListsTabDisplay(config) {
 }
 
 ListsTabDisplay.prototype.attach = function() {
-    var isOnMoviePage = (new RegExp( this.settings.includes[2] )).test(window.location.href),
+    var isOnMoviePage = (new RegExp(this.settings.includes[2])).test(window.location.href),
         _c = this.config;
 
     if (isOnMoviePage) {

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -108,7 +108,7 @@ ICM_BaseFeature.prototype.updateConfig = function(config) {
 function ICM_Config() {
     this.cfg = {
         script_config: { // script config
-            version: "1.7.6.2",
+            version: '1.7.6.2',
             revision: 1762 // numerical representation of version number
         }
     };
@@ -118,7 +118,7 @@ function ICM_Config() {
 
 // Initialize stuff
 ICM_Config.prototype.Init = function() {
-    var oldcfg = evalOrParse(GM_getValue("icm_enhanced_cfg"));
+    var oldcfg = evalOrParse(GM_getValue('icm_enhanced_cfg'));
     if (!oldcfg) {
         return;
     }
@@ -138,7 +138,7 @@ ICM_Config.prototype.Init = function() {
 // Save config
 ICM_Config.prototype.Save = function() {
     // console.log("Saving config", this.cfg); // debug
-    GM_setValue( "icm_enhanced_cfg", JSON.stringify(this.cfg));
+    GM_setValue( 'icm_enhanced_cfg', JSON.stringify(this.cfg));
 };
 
 // Get config value
@@ -158,8 +158,8 @@ ICM_Config.prototype.Toggle = function( index ) {
 
     if ( val === true || val === false ) {
         changeVal = !val;
-    } else if ( val === "asc" || val === "desc" ) {
-        changeVal = val === "asc" ? "desc" : "asc";
+    } else if ( val === 'asc' || val === 'desc' ) {
+        changeVal = val === 'asc' ? 'desc' : 'asc';
     } else {
         return false; // Couldn't toggle a value
     }
@@ -190,14 +190,14 @@ ICM_ConfigWindow.prototype.loadOptions = function(idx) {
             optValue = this.config.Get(index), // always up to date
             indexAttr = ' data-cfg-index="' + index + '"';
 
-        if (opt.type === "checkbox") {
+        if (opt.type === 'checkbox') {
             str += '<p><input type="checkbox"' + indexAttr +
                    (optValue ? ' checked="checked"' : '') + ' title="default: ' +
                    (opt.default ? 'yes' : 'no') + '">' + opt.desc + '</p>';
-        } else if (opt.type === "textinput") {
+        } else if (opt.type === 'textinput') {
             str += '<p>' + opt.desc + ': <input type="text"' + indexAttr +
                    ' value="' + optValue + '" title="default: ' + opt.default + '"></p>';
-        } else if (opt.type === "textarea") {
+        } else if (opt.type === 'textarea') {
             // optValue can be a string (until a module parses it) or an array (after)
             if ($.isArray(optValue)) {
                 optValue = optValue.join('\n');
@@ -205,7 +205,7 @@ ICM_ConfigWindow.prototype.loadOptions = function(idx) {
             str += '<p><span style="vertical-align: top; margin-right: 5px">' + opt.desc +
                    ':</span><textarea rows="4" cols="70"' + indexAttr +
                    '>' + optValue + '</textarea></p>';
-        } else if (opt.type === "textinputcolor") {
+        } else if (opt.type === 'textinputcolor') {
             str += '<p>' + opt.desc + ': <input type="text" class="colorpickertext"' +
                    indexAttr + ' value="' + optValue + '" title="default: ' +
                    opt.default + '">' + ' <input type="text" class="colorpicker"></p>';
@@ -213,7 +213,7 @@ ICM_ConfigWindow.prototype.loadOptions = function(idx) {
         }
     }
 
-    $("#module_settings").html(str);
+    $('#module_settings').html(str);
 
     if (needsExtraInit) {
         this.initColorPickers();
@@ -221,19 +221,19 @@ ICM_ConfigWindow.prototype.loadOptions = function(idx) {
 };
 
 ICM_ConfigWindow.prototype.initColorPickers = function() {
-    $(".colorpicker").each(function(){
+    $('.colorpicker').each(function(){
         var $t = $(this);
         $t.spectrum({
             color: $t.prev().val(),
             change: function(color) {
                 var $prev = $t.prev();
                 $prev.val(color.toHexString());
-                $prev.trigger("change");
+                $prev.trigger('change');
             }
         });
     });
-    $(".colorpickertext").on("change input paste", function() {
-        $(this).next().spectrum("set", $(this).val());
+    $('.colorpickertext').on('change input paste', function() {
+        $(this).next().spectrum('set', $(this).val());
     });
 };
 
@@ -244,7 +244,7 @@ ICM_ConfigWindow.prototype.build = function() {
     // Create and append a new item in the drop down menu under your username
     var cfgLink = '<li><a id="icm_enhanced_cfg" href="#" title="Configure iCheckMovies Enhanced script options">ICM Enhanced</a></li>';
 
-    $("ul#profileOptions").append( cfgLink );
+    $('ul#profileOptions').append( cfgLink );
 
     // Custom CSS for jqmodal
     var customCSS =
@@ -280,12 +280,12 @@ ICM_ConfigWindow.prototype.build = function() {
         '</div>';
 
     // append config window
-    $("body").append( cfgMainHtml );
+    $('body').append( cfgMainHtml );
 
     var _t = this;
 
-    $("div#cfgModal").on( "change", "input, textarea", function() {
-        var index = $(this).data("cfg-index");
+    $('div#cfgModal').on( 'change', 'input, textarea', function() {
+        var index = $(this).data('cfg-index');
         if (index === undefined) {
             return;
         }
@@ -294,27 +294,27 @@ ICM_ConfigWindow.prototype.build = function() {
             _t.config.Set( index, $(this).val() );
         }
 
-        $("button#configSave").prop("disabled", false);
+        $('button#configSave').prop('disabled', false);
     });
 
-    $("div#cfgModal").on( "click", "button#configSave", function() {
+    $('div#cfgModal').on( 'click', 'button#configSave', function() {
         _t.config.Save();
 
-        $(this).prop("disabled", true);
+        $(this).prop('disabled', true);
     });
 
-    $("#modulelist").on("change", function() {
-        var idx = document.getElementById("modulelist").selectedIndex;
+    $('#modulelist').on('change', function() {
+        var idx = document.getElementById('modulelist').selectedIndex;
         _t.loadOptions(idx);
     });
 
-    $("#modulelist").trigger("change");
+    $('#modulelist').trigger('change');
 
     // initialize config window
-    $("#cfgModal").jqm( { trigger: "a#icm_enhanced_cfg" } );
+    $('#cfgModal').jqm( { trigger: 'a#icm_enhanced_cfg' } );
 
     // Initialize spectrum plugin
-    GM_addStyle(GM_getResourceText("spectrumCss"));
+    GM_addStyle(GM_getResourceText('spectrumCss'));
 };
 
 // Inherit methods from BaseFeature
@@ -332,17 +332,17 @@ ICM_RandomFilmLink.prototype.Attach = function() {
     if ( this.config.enabled ) {
         var random_film = '<span style="float:right; margin-left: 15px"><a href="#" id="random_film">Help me pick a film!</a></span>';
 
-        if ( $("div#list_container").length !== 1 ) {
+        if ( $('div#list_container').length !== 1 ) {
             var container = '<div id="list_container" style="height: 35px; position: relative">' + random_film + '</div>';
 
-            $("#movies").parent().before( container );
+            $('#movies').parent().before( container );
         } else {
-            $("div#list_container").append( random_film );
+            $('div#list_container').append( random_film );
         }
 
         var that = this;
 
-        $("div#list_container").on( "click", "a#random_film", function(e) {
+        $('div#list_container').on( 'click', 'a#random_film', function(e) {
             e.preventDefault();
 
             that.PickRandomFilm();
@@ -352,7 +352,7 @@ ICM_RandomFilmLink.prototype.Attach = function() {
 
 // Displays a random film on a list
 ICM_RandomFilmLink.prototype.PickRandomFilm = function() {
-    var $unchecked = $("ol#itemListMovies > li.unchecked"),
+    var $unchecked = $('ol#itemListMovies > li.unchecked'),
         rand_num;
 
     if ( $unchecked.length > 0 ) {
@@ -373,27 +373,27 @@ ICM_RandomFilmLink.prototype.PickRandomFilm = function() {
             rand_num = Math.floor( Math.random() * $unchecked.length );
         }
 
-        $("ol#itemListMovies > li").hide();
+        $('ol#itemListMovies > li').hide();
 
         $( $unchecked[ rand_num ] ).show();
     }
 };
 
 ICM_RandomFilmLink.prototype.settings = {
-    title: "Random film link",
-    desc: "Displays \"Help me pick a film\" link on individual lists",
-    index: "random_film",
-    includes: ["icheckmovies.com/lists/(.+)"],
-    excludes: ["icheckmovies.com/lists/$"],
+    title: 'Random film link',
+    desc: 'Displays "Help me pick a film" link on individual lists',
+    index: 'random_film',
+    includes: ['icheckmovies.com/lists/(.+)'],
+    excludes: ['icheckmovies.com/lists/$'],
     options: [{
-        name: "enabled",
-        desc: "Enabled",
-        type: "checkbox",
+        name: 'enabled',
+        desc: 'Enabled',
+        type: 'checkbox',
         default: true
     }, {
-        name: "unique",
-        desc: "Unique suggestions (shows each entry only once until every entry has been shown once)",
-        type: "checkbox",
+        name: 'unique',
+        desc: 'Unique suggestions (shows each entry only once until every entry has been shown once)',
+        type: 'checkbox',
         default: true
     }]
 };
@@ -407,9 +407,9 @@ function ICM_UpcomingAwardsList(config) {
 }
 
 ICM_UpcomingAwardsList.prototype.Attach = function() {
-    if ( this.config.enabled && $("#itemListMovies").length ) {
-        var total_items = parseInt($("li#listFilterMovies").text().match(/\d+/));
-        var checks      = parseInt($("#topListMoviesCheckedCount").text().match(/\d+/));
+    if ( this.config.enabled && $('#itemListMovies').length ) {
+        var total_items = parseInt($('li#listFilterMovies').text().match(/\d+/));
+        var checks      = parseInt($('#topListMoviesCheckedCount').text().match(/\d+/));
 
         var statistics = '<span><b>Upcoming awards:</b>';
 
@@ -425,31 +425,31 @@ ICM_UpcomingAwardsList.prototype.Attach = function() {
         statistics += get_span('Bronze', 0.5) + get_span('Silver', 0.75) +
                       get_span('Gold', 0.9) + get_span('Platinum', 1);
 
-        if ( $("div#list_container").length !== 1 ) {
+        if ( $('div#list_container').length !== 1 ) {
             var container = '<div id="list_container" style="height: 35px; position: relative">' + statistics + '</div>';
 
-            $("#movies").parent().before( container );
+            $('#movies').parent().before( container );
         } else {
-            $("div#list_container").append( statistics );
+            $('div#list_container').append( statistics );
         }
     }
 };
 
 ICM_UpcomingAwardsList.prototype.settings = {
-    title: "Upcoming awards (individual lists)",
-    desc: "Displays upcoming awards on individual lists",
-    index: "ua_list",
-    includes: ["icheckmovies.com/lists/(.+)"],
-    excludes: ["icheckmovies.com/list/$"],
+    title: 'Upcoming awards (individual lists)',
+    desc: 'Displays upcoming awards on individual lists',
+    index: 'ua_list',
+    includes: ['icheckmovies.com/lists/(.+)'],
+    excludes: ['icheckmovies.com/list/$'],
     options: [{
-        name: "enabled",
-        desc: "Enabled",
-        type: "checkbox",
+        name: 'enabled',
+        desc: 'Enabled',
+        type: 'checkbox',
         default: true
     }, {
-        name: "show_absolute",
-        desc: "Display negative values",
-        type: "checkbox",
+        name: 'show_absolute',
+        desc: 'Display negative values',
+        type: 'checkbox',
         default: true
     }]
 };
@@ -472,11 +472,11 @@ ICM_UpcomingAwardsOverview.prototype.Attach = function() {
         } else {
             var load_link = '<p id="lad_container"><a id="load_award_data" href="#">Load upcoming awards for this user</a></p>';
 
-            $("#listOrdering").before(load_link);
+            $('#listOrdering').before(load_link);
 
             var that = this;
 
-            $("p#lad_container").on("click", "a#load_award_data", function(e) {
+            $('p#lad_container').on('click', 'a#load_award_data', function(e) {
                 e.preventDefault();
 
                 $( e.target ).remove();
@@ -489,7 +489,7 @@ ICM_UpcomingAwardsOverview.prototype.Attach = function() {
 
 ICM_UpcomingAwardsOverview.prototype.LoadAwardData = function() {
     this.lists = [];
-    this.hidden_lists = evalOrParse(GM_getValue("hidden_lists", "[]"));
+    this.hidden_lists = evalOrParse(GM_getValue('hidden_lists', '[]'));
 
     this.PopulateLists();
     this.SortLists();
@@ -498,11 +498,11 @@ ICM_UpcomingAwardsOverview.prototype.LoadAwardData = function() {
 
 ICM_UpcomingAwardsOverview.prototype.PopulateLists = function() {
     var that = this,
-        $all_lists = $("ol#progressall, ol#itemListToplists").children("li"),
-        sel = {progress: {rank: "span.rank", title: "h3 > a"},
-               lists: {rank: "span.info > strong:first", title: "h2 > a.title"}},
+        $all_lists = $('ol#progressall, ol#itemListToplists').children('li'),
+        sel = {progress: {rank: 'span.rank', title: 'h3 > a'},
+               lists: {rank: 'span.info > strong:first', title: 'h2 > a.title'}},
         // use different selectors depending on page
-        curSel = location.href.indexOf("progress") !== -1 ?
+        curSel = location.href.indexOf('progress') !== -1 ?
                  sel.progress : sel.lists,
         award_types = [['Platinum', 1], ['Gold', 0.9], ['Silver', 0.75], ['Bronze', 0.5]];
 
@@ -517,8 +517,8 @@ ICM_UpcomingAwardsOverview.prototype.PopulateLists = function() {
         var checks      = parseInt( count_arr[0], 10 ),
             total_items = parseInt( count_arr[1], 10 ),
             $t          = $el.find(curSel.title),
-            list_title  = $t.attr("title").replace(/^View the | top list$/g, ""),
-            list_url    = $t.attr("href");
+            list_title  = $t.attr('title').replace(/^View the | top list$/g, ''),
+            list_url    = $t.attr('href');
 
         award_types.forEach(function(award) {
             var award_checks = Math.ceil(total_items * award[1]) - checks;
@@ -539,7 +539,7 @@ ICM_UpcomingAwardsOverview.prototype.PopulateLists = function() {
 ICM_UpcomingAwardsOverview.prototype.SortLists = function() {
     // sort lists array by least required checks ASC,
     // then by awards where checks are equal ASC, then by list title ASC
-    var award_order = { "Bronze": 0, "Silver": 1, "Gold": 2, "Platinum": 3 };
+    var award_order = { 'Bronze': 0, 'Silver': 1, 'Gold': 2, 'Platinum': 3 };
     this.lists.sort(function(a, b) {
         if (a.award_checks < b.award_checks) {
             return -1;
@@ -559,8 +559,8 @@ ICM_UpcomingAwardsOverview.prototype.SortLists = function() {
 };
 
 ICM_UpcomingAwardsOverview.prototype.HTMLOut = function() {
-    var unhide_icon_data = "data:text/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAGrSURBVDjLvZPZLkNhFIV75zjvYm7VGFNCqoZUJ+roKUUpjRuqp61Wq0NKDMelGGqOxBSUIBKXWtWGZxAvobr8lWjChRgSF//dv9be+9trCwAI/vIE/26gXmviW5bqnb8yUK028qZjPfoPWEj4Ku5HBspgAz941IXZeze8N1bottSo8BTZviVWrEh546EO03EXpuJOdG63otJbjBKHkEp/Ml6yNYYzpuezWL4s5VMtT8acCMQcb5XL3eJE8VgBlR7BeMGW9Z4yT9y1CeyucuhdTGDxfftaBO7G4L+zg91UocxVmCiy51NpiP3n2treUPujL8xhOjYOzZYsQWANyRYlU4Y9Br6oHd5bDh0bCpSOixJiWx71YY09J5pM/WEbzFcDmHvwwBu2wnikg+lEj4mwBe5bC5h1OUqcwpdC60dxegRmR06TyjCF9G9z+qM2uCJmuMJmaNZaUrCSIi6X+jJIBBYtW5Cge7cd7sgoHDfDaAvKQGAlRZYc6ltJlMxX03UzlaRlBdQrzSCwksLRbOpHUSb7pcsnxCCwngvM2Rm/ugUCi84fycr4l2t8Bb6iqTxSCgNIAAAAAElFTkSuQmCC";
-    var hide_icon_data = "data:text/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADtSURBVHjajFC7DkFREJy9iXg0t+EHRKJDJSqRuIVaJT7AF+jR+xuNRiJyS8WlRaHWeOU+kBy7eyKhs8lkJrOzZ3OWzMAD15gxYhB+yzAm0ndez+eYMYLngdkIf2vpSYbCfsNkOx07n8kgWa1UpptNII5VR/M56Nyt6Qq33bbhQsHy6aR0WSyEyEmiCG6vR2ffB65X4HCwYC2e9CTjJGGok4/7Hcjl+ImLBWv1uCRDu3peV5eGQ2C5/P1zq4X9dGpXP+LYhmYz4HbDMQgUosWTnmQoKKf0htVKBZvtFsx6S9bm48ktaV3EXwd/CzAAVjt+gHT5me0AAAAASUVORK5CYII=";
+    var unhide_icon_data = 'data:text/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAAGrSURBVDjLvZPZLkNhFIV75zjvYm7VGFNCqoZUJ+roKUUpjRuqp61Wq0NKDMelGGqOxBSUIBKXWtWGZxAvobr8lWjChRgSF//dv9be+9trCwAI/vIE/26gXmviW5bqnb8yUK028qZjPfoPWEj4Ku5HBspgAz941IXZeze8N1bottSo8BTZviVWrEh546EO03EXpuJOdG63otJbjBKHkEp/Ml6yNYYzpuezWL4s5VMtT8acCMQcb5XL3eJE8VgBlR7BeMGW9Z4yT9y1CeyucuhdTGDxfftaBO7G4L+zg91UocxVmCiy51NpiP3n2treUPujL8xhOjYOzZYsQWANyRYlU4Y9Br6oHd5bDh0bCpSOixJiWx71YY09J5pM/WEbzFcDmHvwwBu2wnikg+lEj4mwBe5bC5h1OUqcwpdC60dxegRmR06TyjCF9G9z+qM2uCJmuMJmaNZaUrCSIi6X+jJIBBYtW5Cge7cd7sgoHDfDaAvKQGAlRZYc6ltJlMxX03UzlaRlBdQrzSCwksLRbOpHUSb7pcsnxCCwngvM2Rm/ugUCi84fycr4l2t8Bb6iqTxSCgNIAAAAAElFTkSuQmCC';
+    var hide_icon_data = 'data:text/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1hZ2VSZWFkeXHJZTwAAADtSURBVHjajFC7DkFREJy9iXg0t+EHRKJDJSqRuIVaJT7AF+jR+xuNRiJyS8WlRaHWeOU+kBy7eyKhs8lkJrOzZ3OWzMAD15gxYhB+yzAm0ndez+eYMYLngdkIf2vpSYbCfsNkOx07n8kgWa1UpptNII5VR/M56Nyt6Qq33bbhQsHy6aR0WSyEyEmiCG6vR2ffB65X4HCwYC2e9CTjJGGok4/7Hcjl+ImLBWv1uCRDu3peV5eGQ2C5/P1zq4X9dGpXP+LYhmYz4HbDMQgUosWTnmQoKKf0htVKBZvtFsx6S9bm48ktaV3EXwd/CzAAVjt+gHT5me0AAAAASUVORK5CYII=';
 
     var list_table = '<table id="award_table"><thead><tr id="award_table_head"><th>Awards</th><th>Checks</th><th>List title</th><th>(Un)Hide</th></tr></head><tbody>';
 
@@ -570,7 +570,7 @@ ICM_UpcomingAwardsOverview.prototype.HTMLOut = function() {
             hide_icon = '<img title="Hide ' + el.list_title + '" alt="Hide icon" src="' + hide_icon_data + '">',
             is_hidden = this.hidden_lists.indexOf(el.list_url) !== -1;
 
-        list_table  += '<tr class="' + (is_hidden ? "hidden-list" : "") +
+        list_table  += '<tr class="' + (is_hidden ? 'hidden-list' : '') +
             '" data-award-type="' + el.award_type + '" data-list-url="' + el.list_url + '">' +
             '<td style="width: 65px">' + el.award_type + '</td>' +
             '<td style="width: 65px">' + el.award_checks + '</td>' +
@@ -593,27 +593,27 @@ ICM_UpcomingAwardsOverview.prototype.HTMLOut = function() {
 
     var all_html = '<div id="icm_award_html_container" style="z-index: 0; position: relative; margin-top: 0; margin-bottom: 20px">' + toggle_upcoming_link + links + award_container + '</div>';
 
-    $("#icm_award_html_container, #ua_toggle_link_container").remove();
+    $('#icm_award_html_container, #ua_toggle_link_container').remove();
 
-    if (location.href.indexOf("progress") !== -1) {
-        $("#listOrdering").before(all_html);
+    if (location.href.indexOf('progress') !== -1) {
+        $('#listOrdering').before(all_html);
     } else {
-        $("#itemContainer").before(all_html);
+        $('#itemContainer').before(all_html);
     }
 
-    var $lists = $("#award_table > tbody > tr");
+    var $lists = $('#award_table > tbody > tr');
 
     // hide hidden
-    $lists.filter(".hidden-list").hide();
+    $lists.filter('.hidden-list').hide();
 
     var _this = this;
 
-    $("a.icm_hide_list").on("click", function(e) {
+    $('a.icm_hide_list').on('click', function(e) {
         e.preventDefault();
 
         var $parent = $(this).parent().parent(),
-            list_title = $.trim($parent.find(".list-title").text()),
-            list_url = $parent.data("list-url"),
+            list_title = $.trim($parent.find('.list-title').text()),
+            list_url = $parent.data('list-url'),
             ind = _this.hidden_lists.indexOf(list_url),
             hide = ind === -1;
 
@@ -623,85 +623,85 @@ ICM_UpcomingAwardsOverview.prototype.HTMLOut = function() {
             _this.hidden_lists.splice(ind, 1);
         }
 
-        $lists.filter(hide ? "tr" : "tr.hidden-list")
+        $lists.filter(hide ? 'tr' : 'tr.hidden-list')
             .filter(function() { // get all awards with the same url
-                return $(this).data("list-url") === list_url;
+                return $(this).data('list-url') === list_url;
             })
-            .toggleClass("hidden-list", hide).hide()
-            .find(".icm_hide_list > img").attr({
+            .toggleClass('hidden-list', hide).hide()
+            .find('.icm_hide_list > img').attr({
                 src: hide ? unhide_icon_data : hide_icon_data,
-                alt: (hide ? "Unhide " : "Hide ") + "Icon",
-                title: (hide ? "Unhide " : "Hide ") + list_title
+                alt: (hide ? 'Unhide ' : 'Hide ') + 'Icon',
+                title: (hide ? 'Unhide ' : 'Hide ') + list_title
             });
 
         // save hidden lists
-        GM_setValue("hidden_lists", JSON.stringify(_this.hidden_lists));
+        GM_setValue('hidden_lists', JSON.stringify(_this.hidden_lists));
     });
 
-    $("#toggle_hidden_list").on("click", function(e) {
+    $('#toggle_hidden_list').on('click', function(e) {
         e.preventDefault();
 
         $lists.hide();
-        $lists.filter(".hidden-list").show();
+        $lists.filter('.hidden-list').show();
     });
 
-    $("#ua_toggle_link_container").on("click", "a#toggle_upcoming_awards span", function(e) {
+    $('#ua_toggle_link_container').on('click', 'a#toggle_upcoming_awards span', function(e) {
         e.preventDefault();
 
-        $("#award_display_links, #award_container").toggle();
-        $("a#toggle_upcoming_awards span").toggle();
+        $('#award_display_links, #award_container').toggle();
+        $('a#toggle_upcoming_awards span').toggle();
     });
 
-    $("#award_display_links").on("click", "a#display_all", function(e) {
+    $('#award_display_links').on('click', 'a#display_all', function(e) {
         e.preventDefault();
 
         $lists.hide();
-        $lists.not(".hidden-list").show();
+        $lists.not('.hidden-list').show();
     });
 
-    $("#award_display_links").on("click", "a#display_bronze, a#display_silver, a#display_gold, a#display_platinum", function(e) {
+    $('#award_display_links').on('click', 'a#display_bronze, a#display_silver, a#display_gold, a#display_platinum', function(e) {
         e.preventDefault();
 
-        var award_type = $(this).attr("id").split('_')[1];
+        var award_type = $(this).attr('id').split('_')[1];
         $lists.hide().filter(function() {
-            return !$(this).hasClass("hidden-list") &&
-                    $(this).data("award-type").toLowerCase() === award_type;
+            return !$(this).hasClass('hidden-list') &&
+                    $(this).data('award-type').toLowerCase() === award_type;
         }).show();
     });
 
-    $("#award_display_links").on("click", "a#toggle_full_list span._show", function(e) {
+    $('#award_display_links').on('click', 'a#toggle_full_list span._show', function(e) {
         e.preventDefault();
 
-        $("a#toggle_full_list span").toggle();
-        $("div#award_container").css("height", "auto");
+        $('a#toggle_full_list span').toggle();
+        $('div#award_container').css('height', 'auto');
     });
 
-    $("#award_display_links").on("click", "a#toggle_full_list span._hide", function(e) {
+    $('#award_display_links').on('click', 'a#toggle_full_list span._hide', function(e) {
         e.preventDefault();
 
-        $("a#toggle_full_list span").toggle();
-        $("div#award_container").css("height", "240px");
+        $('a#toggle_full_list span').toggle();
+        $('div#award_container').css('height', '240px');
     });
 };
 
 ICM_UpcomingAwardsOverview.prototype.settings = {
-    title: "Upcoming awards overview",
-    desc: "Displays upcoming awards on progress page",
-    index: "ua",
-    includes: ["/profiles/progress/",
-               "/lists/favorited/",
-               "/lists/watchlist/",
-               "/lists/disliked/"],
+    title: 'Upcoming awards overview',
+    desc: 'Displays upcoming awards on progress page',
+    index: 'ua',
+    includes: ['/profiles/progress/',
+               '/lists/favorited/',
+               '/lists/watchlist/',
+               '/lists/disliked/'],
     excludes: [],
     options: [{
-        name: "enabled",
-        desc: "Enabled",
-        type: "checkbox",
+        name: 'enabled',
+        desc: 'Enabled',
+        type: 'checkbox',
         default: true
     }, {
-        name: "autoload",
-        desc: "Autoload",
-        type: "checkbox",
+        name: 'autoload',
+        desc: 'Autoload',
+        type: 'checkbox',
         default: true
     }]
 };
@@ -716,7 +716,7 @@ function ICM_ListCustomColors(config) {
 
 ICM_ListCustomColors.prototype.Attach = function() {
     if ( this.config.enabled ) {
-        var list_colors_css = "";
+        var list_colors_css = '';
 
         var buildCSS = function(className, color) {
             if (!color.length) {
@@ -735,31 +735,31 @@ ICM_ListCustomColors.prototype.Attach = function() {
 };
 
 ICM_ListCustomColors.prototype.settings = {
-    title: "Custom list colors",
-    desc: "Changes entry colors on lists to visually separate entries in your favorites/watchlist/dislikes",
-    index: "list_colors",
-    includes: ["icheckmovies.com/"],
+    title: 'Custom list colors',
+    desc: 'Changes entry colors on lists to visually separate entries in your favorites/watchlist/dislikes',
+    index: 'list_colors',
+    includes: ['icheckmovies.com/'],
     excludes: [],
     options: [{
-        name: "enabled",
-        desc: "Enabled",
-        type: "checkbox",
+        name: 'enabled',
+        desc: 'Enabled',
+        type: 'checkbox',
         default: true
     }, {
-        name: "colors.favorite",
-        desc: "Favorites",
-        type: "textinputcolor",
-        default: "#ffdda9"
+        name: 'colors.favorite',
+        desc: 'Favorites',
+        type: 'textinputcolor',
+        default: '#ffdda9'
     }, {
-        name: "colors.watchlist",
-        desc: "Watchlist",
-        type: "textinputcolor",
-        default: "#ffffd6"
+        name: 'colors.watchlist',
+        desc: 'Watchlist',
+        type: 'textinputcolor',
+        default: '#ffffd6'
     }, {
-        name: "colors.disliked",
-        desc: "Disliked",
-        type: "textinputcolor",
-        default: "#ffad99"
+        name: 'colors.disliked',
+        desc: 'Disliked',
+        type: 'textinputcolor',
+        default: '#ffad99'
     }]
 };
 
@@ -797,15 +797,15 @@ ICM_ListCrossCheck.prototype.Init = function() {
 };
 
 ICM_ListCrossCheck.prototype.Attach = function() {
-    if (this.config.enabled && $("#itemListToplists").length) {
+    if (this.config.enabled && $('#itemListToplists').length) {
         var actions = '<div id="crActions" style="margin-bottom: 18px"><button id="cfgListCCActivate">Activate CR</button></div>';
 
-        $("#itemContainer").before(actions);
+        $('#itemContainer').before(actions);
 
         var _t = this;
 
-        $("div#crActions").on( "click", "button#cfgListCCActivate", function() {
-            $(this).prop("disabled", true);
+        $('div#crActions').on( 'click', 'button#cfgListCCActivate', function() {
+            $(this).prop('disabled', true);
 
             _t.CreateTab();
 
@@ -819,7 +819,7 @@ ICM_ListCrossCheck.prototype.Attach = function() {
             'ol#itemListToplists li.icme_listcc_pending, .icme_listcc_pending .progress { background-color: #ffffb2 !important; }' +
             '</style>';
 
-        $("body").append(customCSS);
+        $('body').append(customCSS);
     }
 };
 
@@ -830,30 +830,30 @@ ICM_ListCrossCheck.prototype.Activate = function() {
 
     var _t = this;
 
-    $("button#cfgListCCActivate").after(' <button id="cfgListCCDeactivate">Deactivate</button>');
+    $('button#cfgListCCActivate').after(' <button id="cfgListCCDeactivate">Deactivate</button>');
 
-    $("div#crActions").on("click", "button#cfgListCCDeactivate", function() {
+    $('div#crActions').on('click', 'button#cfgListCCDeactivate', function() {
         _t.Deactivate();
 
-        $("button#cfgListCCActivate").prop("disabled", false);
+        $('button#cfgListCCActivate').prop('disabled', false);
     });
 
     if ( !this.activated_once ) { // ff 3.6 compatibility (ff 3.6 fails to unbind the events in all possible ways)
-        $("ol#itemListToplists li").on("click mouseover mouseout", function(e) {
+        $('ol#itemListToplists li').on('click mouseover mouseout', function(e) {
             if ( _t.activated && !_t.in_progress ) { // ff 3.6 compatibility
                 // these event actions must not work for cloned toplists under the selected tab
-                if ( !$(this).hasClass("icme_listcc") ) {
-                    if ( e.type === "mouseover" && !$(this).hasClass("icme_listcc_selected") ) {
-                        $(this).addClass("icme_listcc_hover").find("span.percentage").hide();
-                    } else if ( e.type === "mouseout" && !$(this).hasClass("icme_listcc_selected") ) {
-                        $(this).removeClass("icme_listcc_hover").find("span.percentage").show();
-                    } else if ( e.type === "click" ) {
-                        $(this).removeClass("icme_listcc_hover");
+                if ( !$(this).hasClass('icme_listcc') ) {
+                    if ( e.type === 'mouseover' && !$(this).hasClass('icme_listcc_selected') ) {
+                        $(this).addClass('icme_listcc_hover').find('span.percentage').hide();
+                    } else if ( e.type === 'mouseout' && !$(this).hasClass('icme_listcc_selected') ) {
+                        $(this).removeClass('icme_listcc_hover').find('span.percentage').show();
+                    } else if ( e.type === 'click' ) {
+                        $(this).removeClass('icme_listcc_hover');
 
-                        if ( $(this).hasClass("icme_listcc_selected") ) {
-                            $(this).removeClass("icme_listcc_selected").addClass("icme_listcc_hover");
+                        if ( $(this).hasClass('icme_listcc_selected') ) {
+                            $(this).removeClass('icme_listcc_selected').addClass('icme_listcc_hover');
                         } else {
-                            $(this).addClass("icme_listcc_selected");
+                            $(this).addClass('icme_listcc_selected');
                         }
                     }
                 }
@@ -867,15 +867,15 @@ ICM_ListCrossCheck.prototype.Activate = function() {
 };
 
 ICM_ListCrossCheck.prototype.Deactivate = function() {
-    var selected_toplists = $("li.icme_listcc_selected", "ul#topLists");
+    var selected_toplists = $('li.icme_listcc_selected', 'ul#topLists');
 
     // if there's still selected top lists, change them back to normal
-    $(selected_toplists).removeClass("icme_listcc_selected").find("span.percentage").show();
+    $(selected_toplists).removeClass('icme_listcc_selected').find('span.percentage').show();
 
-    $("ol#itemListToplists").children("li").removeClass("icme_listcc_selected").removeClass("icme_listcc_hover");
-    $("button#icme_listcc_check, button#cfgListCCDeactivate").remove();
-    $("li#topListCategoryCCSelected").remove();
-    $("button#cfgListCCActivate").prop("disabled", false);
+    $('ol#itemListToplists').children('li').removeClass('icme_listcc_selected').removeClass('icme_listcc_hover');
+    $('button#icme_listcc_check, button#cfgListCCDeactivate').remove();
+    $('li#topListCategoryCCSelected').remove();
+    $('button#cfgListCCActivate').prop('disabled', false);
 
     this.Init();
 };
@@ -884,20 +884,20 @@ ICM_ListCrossCheck.prototype.Deactivate = function() {
  * Check through every selected top list
  */
 ICM_ListCrossCheck.prototype.Check = function() {
-    var toplist_cnt = $("ol#itemListToplists");
+    var toplist_cnt = $('ol#itemListToplists');
 
     // make selected top lists normal under the regular tabs
-    toplist_cnt.children("li.icme_listcc_selected").removeClass("icme_listcc_selected").find("span.percentage").show();
+    toplist_cnt.children('li.icme_listcc_selected').removeClass('icme_listcc_selected').find('span.percentage').show();
 
     // get selected top lists
-    var jq_toplists = toplist_cnt.children("li.icme_listcc");
+    var jq_toplists = toplist_cnt.children('li.icme_listcc');
 
     this.num_toplists = jq_toplists.length;
     this.in_progress = true;
 
     // sort selected top lists in ascending order by number of unchecked films
     var get_unchecked = function(x) {
-        var checks = $(x).find("span.info > strong:first").text().split("/");
+        var checks = $(x).find('span.info > strong:first').text().split('/');
         return checks[1] - checks[0];
     };
     jq_toplists.sort(function(a, b) {
@@ -905,7 +905,7 @@ ICM_ListCrossCheck.prototype.Check = function() {
     });
 
     // make selected toplists highlighted under the selected tab
-    jq_toplists.addClass("icme_listcc_selected").find("span.percentage").hide();
+    jq_toplists.addClass('icme_listcc_selected').find('span.percentage').hide();
 
     this.toplists = jq_toplists.get();
     this.GetUncheckedFilms(this.toplists[this.sequence_number]);
@@ -917,18 +917,18 @@ ICM_ListCrossCheck.prototype.Check = function() {
  * @param list_elem jQuery object of the top list element
  */
 ICM_ListCrossCheck.prototype.GetUncheckedFilms = function(list_elem) {
-    var url = $(list_elem).find("a").attr("href");
+    var url = $(list_elem).find('a').attr('href');
 
-    $(list_elem).addClass("icme_listcc_pending");
+    $(list_elem).addClass('icme_listcc_pending');
 
     var _t = this;
 
     $.get(url, function(response) {
-        $(list_elem).removeClass("icme_listcc_selected icme_listcc_pending").find("span.percentage").show();
+        $(list_elem).removeClass('icme_listcc_selected icme_listcc_pending').find('span.percentage').show();
 
-        var filter = _t.config.checks ? "" : "li.unchecked";
+        var filter = _t.config.checks ? '' : 'li.unchecked';
         // the site returns html with extra whitespace
-        var unchecked = $($.parseHTML(response)).find("ol#itemListMovies").children(filter);
+        var unchecked = $($.parseHTML(response)).find('ol#itemListMovies').children(filter);
 
         _t.UpdateMovies( unchecked );
     });
@@ -940,7 +940,7 @@ ICM_ListCrossCheck.prototype.GetUncheckedFilms = function(list_elem) {
  * @param content jQuery object that consists of unchecked movies (<li> elements) on a top list page
  */
 ICM_ListCrossCheck.prototype.UpdateMovies = function(content) {
-    var movie_titles = content.find("h2");
+    var movie_titles = content.find('h2');
 
     this.sequence_number += 1;
 
@@ -956,8 +956,8 @@ ICM_ListCrossCheck.prototype.UpdateMovies = function(content) {
         var found = false,
             cur_title = $(movie_titles[i]),
             movie = $.trim(cur_title.text()),
-            movie_url = cur_title.find("a").attr("href"),
-            movie_year = cur_title.next("span.info").children("a:first").text();
+            movie_url = cur_title.find('a').attr('href'),
+            movie_year = cur_title.next('span.info').children('a:first').text();
 
         for ( var j = 0; j < this.movies.length; j++ ) {
             // compare urls as they're guaranteed to be unique
@@ -966,7 +966,7 @@ ICM_ListCrossCheck.prototype.UpdateMovies = function(content) {
             if ( movie_url === this.movies[j].u ) {
                 this.movies[j].c += 1;
 
-                this.movies[j].jq.find(".rank").html(this.movies[j].c);
+                this.movies[j].jq.find('.rank').html(this.movies[j].c);
                 found = true;
 
                 global_toplist_match = true;
@@ -981,14 +981,14 @@ ICM_ListCrossCheck.prototype.UpdateMovies = function(content) {
             // OR if the script is checking for matches on all top lists, but this is just the first top list
             if ( !show_perfect_matches || this.sequence_number === 1 ) {
                 var $item = $(content[i]);
-                $item.find(".rank").html("0");
+                $item.find('.rank').html('0');
 
-                var itemid = $item.attr("id");
+                var itemid = $item.attr('id');
 
                 // check if owned
-                var owned = evalOrParse(GM_getValue("owned_movies", "[]"));
+                var owned = evalOrParse(GM_getValue('owned_movies', '[]'));
                 if (owned.indexOf(itemid) !== -1) {
-                    $item.removeClass("notowned").addClass("owned");
+                    $item.removeClass('notowned').addClass('owned');
                 }
 
                 // t = title, c = count, u = url, y = year
@@ -1069,7 +1069,7 @@ ICM_ListCrossCheck.prototype.OutputMovies = function() {
 
         var menu = '<ul>';
         for (var i = 0; i < this.toplists.length; ++i) {
-            menu += '<li><b>' + $(this.toplists[i]).find("h2").text() + '</b></li>';
+            menu += '<li><b>' + $(this.toplists[i]).find('h2').text() + '</b></li>';
         }
 
         menu += '</ul><ul class="tabMenu tabMenuPush">' +
@@ -1084,44 +1084,44 @@ ICM_ListCrossCheck.prototype.OutputMovies = function() {
             '</ul>';
 
         // hide previous movie list
-        $("#itemListMovies").removeAttr("id").hide();
+        $('#itemListMovies').removeAttr('id').hide();
 
-        $("#itemContainer").after('<ol id="itemListMovies" class="itemList listViewNormal"></ol>');
-        $("#itemContainer").after(menu);
+        $('#itemContainer').after('<ol id="itemListMovies" class="itemList listViewNormal"></ol>');
+        $('#itemContainer').after(menu);
         for (i = 0; i < this.movies.length; ++i) {
-            $("#itemListMovies").append(this.movies[i].jq);
+            $('#itemListMovies').append(this.movies[i].jq);
         }
 
-        $("#itemListMovies").children("li").show();
+        $('#itemListMovies').children('li').show();
 
-        $(".topListMoviesFilter a").on("click", function(e) {
+        $('.topListMoviesFilter a').on('click', function(e) {
             e.preventDefault();
             e.stopImmediatePropagation();
 
             var $this = $(this),
                 $movielist = $this.parent().parent().next();
 
-            if ($movielist.is(":visible")) {
-                $this.parent().removeClass("active");
-                $movielist.removeAttr("id").hide();
+            if ($movielist.is(':visible')) {
+                $this.parent().removeClass('active');
+                $movielist.removeAttr('id').hide();
             } else {
-                $this.parent().addClass("active");
-                $movielist.attr("id", "itemListMovies").show();
+                $this.parent().addClass('active');
+                $movielist.attr('id', 'itemListMovies').show();
             }
         });
-        $(".listFilterExportCSV a").on("click", function(e) {
+        $('.listFilterExportCSV a').on('click', function(e) {
             e.preventDefault();
 
             var data = '"found_toplists","title","year","official_toplists","imdb"\n',
-                $items = $("#itemListMovies").children("li");
+                $items = $('#itemListMovies').children('li');
 
             for (var i = 0; i < $items.length; ++i) {
                 var $item = $($items[i]),
-                    found_toplists = $item.find(".rank").text(),
-                    title = $item.find("h2").text().trim().replace('"', '""'),
-                    year = $item.find(".info a:first").text(),
-                    toplists = parseInt($item.find(".info a:last").text()),
-                    imdburl = $item.find(".optionIMDB").attr("href"),
+                    found_toplists = $item.find('.rank').text(),
+                    title = $item.find('h2').text().trim().replace('"', '""'),
+                    year = $item.find('.info a:first').text(),
+                    toplists = parseInt($item.find('.info a:last').text()),
+                    imdburl = $item.find('.optionIMDB').attr('href'),
                     line = '"' + found_toplists + '",' +
                            '"' + title + '",' +
                            '"' + year + '",' +
@@ -1131,110 +1131,110 @@ ICM_ListCrossCheck.prototype.OutputMovies = function() {
                 data += line;
             }
 
-            window.location.href = "data:text/csv;charset=utf-8," + encodeURIComponent(data);
+            window.location.href = 'data:text/csv;charset=utf-8,' + encodeURIComponent(data);
         });
     } else {
-        $("#icme-crossref-notfound").remove();
-        $("#itemContainer").after('<div id="icme-crossref-notfound">Found 0 movies.</div>');
+        $('#icme-crossref-notfound').remove();
+        $('#itemContainer').after('<div id="icme-crossref-notfound">Found 0 movies.</div>');
     }
 
     this.Deactivate();
 };
 
 ICM_ListCrossCheck.prototype.CreateTab = function() {
-    if ($("#listFilterCRSelected").length) {
+    if ($('#listFilterCRSelected').length) {
         return;
     }
 
     var tab = '<li id="listFilterCRSelected"><a href="#" class="icme_listcc">Cross-reference</a><strong style="display: none">Cross-reference</strong></li>';
 
-    var $tlfilter = $("ul.tabMenu", "div#itemContainer");
+    var $tlfilter = $('ul.tabMenu', 'div#itemContainer');
     $tlfilter.append( tab );
 
     var _t = this;
 
     // Modified from ICM source. Make the tab work.
-    $("#listFilterCRSelected a").on("click", function () {
-        var a = $(this).attr("class"),
-            b = $(this).closest("li");
-        $(".tabMenu").find("li").each(function () {
-            $(this).removeClass("active");
+    $('#listFilterCRSelected a').on('click', function () {
+        var a = $(this).attr('class'),
+            b = $(this).closest('li');
+        $('.tabMenu').find('li').each(function () {
+            $(this).removeClass('active');
         });
-        b.addClass("active");
+        b.addClass('active');
 
-        if ( a === "icme_listcc" && !_t.in_progress ) {
-            var $top_list_ul = $("ol#itemListToplists");
-            $top_list_ul.children("li.icme_listcc").remove();
+        if ( a === 'icme_listcc' && !_t.in_progress ) {
+            var $top_list_ul = $('ol#itemListToplists');
+            $top_list_ul.children('li.icme_listcc').remove();
 
-            var $top_lists = $top_list_ul.children("li.icme_listcc_selected").clone();
+            var $top_lists = $top_list_ul.children('li.icme_listcc_selected').clone();
 
             //$top_list_ul.children("li.icme_listcc_selected").removeClass("icme_listcc_selected");
 
-            $top_lists.removeClass("imdb critics prizes website institute misc icme_listcc_selected").addClass("icme_listcc").find("span.percentage").show();
+            $top_lists.removeClass('imdb critics prizes website institute misc icme_listcc_selected').addClass('icme_listcc').find('span.percentage').show();
 
             $top_list_ul.append( $top_lists );
 
-            if ( $("li.icme_listcc", "ol#itemListToplists").length >= 2 && $("button#icme_listcc_check").length === 0 ) {
+            if ( $('li.icme_listcc', 'ol#itemListToplists').length >= 2 && $('button#icme_listcc_check').length === 0 ) {
                 var btn = '<button id="icme_listcc_check">Cross-reference</button>';
 
-                $("div#crActions").append(btn);
+                $('div#crActions').append(btn);
 
-                $("button#icme_listcc_check").on("click", function() {
-                    $(this).prop("disabled", true);
+                $('button#icme_listcc_check').on('click', function() {
+                    $(this).prop('disabled', true);
 
                     _t.Check();
                 });
 
                 // Make the current tab work if we want to return to it
-                $("ul.tabMenu").children("li").each(function() {
-                    if (!$(this).children("a").length) {
+                $('ul.tabMenu').children('li').each(function() {
+                    if (!$(this).children('a').length) {
                         var $clicked = $(this);
-                        $clicked.on("click", function() {
-                            $("ol#itemListToplists").children("li").show();
-                            $("ul.tabMenu").children("li").removeClass("active");
-                            $clicked.addClass("active");
-                            $("ol#itemListToplists").children("li.icme_listcc").remove();
+                        $clicked.on('click', function() {
+                            $('ol#itemListToplists').children('li').show();
+                            $('ul.tabMenu').children('li').removeClass('active');
+                            $clicked.addClass('active');
+                            $('ol#itemListToplists').children('li.icme_listcc').remove();
                         });
                     }
                 });
-            } else if ( $("li.icme_listcc", "ol#itemListToplists").length < 2 && $("button#icme_listcc_check").length === 1 ) {
-                $("button#icme_listcc_check").remove();
+            } else if ( $('li.icme_listcc', 'ol#itemListToplists').length < 2 && $('button#icme_listcc_check').length === 1 ) {
+                $('button#icme_listcc_check').remove();
             }
         }
 
-        b = $("ol#itemListToplists");
-        b.find("li").hide();
-        b.find("li." + a).show();
+        b = $('ol#itemListToplists');
+        b.find('li').hide();
+        b.find('li.' + a).show();
 
         return false;
     });
 };
 
 ICM_ListCrossCheck.prototype.settings = {
-    title: "List cross-reference",
-    desc: "Cross-reference lists to find what films they share",
-    index: "list_cross_ref",
-    includes: ["icheckmovies.com/lists/"],
+    title: 'List cross-reference',
+    desc: 'Cross-reference lists to find what films they share',
+    index: 'list_cross_ref',
+    includes: ['icheckmovies.com/lists/'],
     excludes: [],
     options: [{
-        name: "enabled",
-        desc: "Enabled",
-        type: "checkbox",
+        name: 'enabled',
+        desc: 'Enabled',
+        type: 'checkbox',
         default: false
     }, {
-        name: "match_all",
-        desc: "Find films that appear on all selected lists",
-        type: "checkbox",
+        name: 'match_all',
+        desc: 'Find films that appear on all selected lists',
+        type: 'checkbox',
         default: true
     }, {
-        name: "match_min",
-        desc: "If the above checkbox is unchecked, find films that appear on this many lists",
-        type: "textinput",
+        name: 'match_min',
+        desc: 'If the above checkbox is unchecked, find films that appear on this many lists',
+        type: 'textinput',
         default: 2
     }, {
-        name: "checks",
-        desc: "Include your checks in results (full intersection)",
-        type: "checkbox",
+        name: 'checks',
+        desc: 'Include your checks in results (full intersection)',
+        type: 'checkbox',
         default: false
     }]
 };
@@ -1249,29 +1249,29 @@ function ICM_HideTags(config) {
 
 ICM_HideTags.prototype.Attach = function() {
     if (this.config.enabled) {
-        GM_addStyle("ol#itemListToplists li .info:last-child, ol#itemListMovies li .tagList { display: none !important; }");
+        GM_addStyle('ol#itemListToplists li .info:last-child, ol#itemListMovies li .tagList { display: none !important; }');
 
         if (this.config.show_hover) {
-            GM_addStyle("ol#itemListToplists li:hover .info:last-child, ol#itemListMovies li:hover .tagList { display: block !important; }");
+            GM_addStyle('ol#itemListToplists li:hover .info:last-child, ol#itemListMovies li:hover .tagList { display: block !important; }');
         }
     }
 };
 
 ICM_HideTags.prototype.settings = {
-    title: "Hide tags",
-    desc: "Hides tags on individual lists",
-    index: "hide_tags",
-    includes: ["icheckmovies.com/"],
+    title: 'Hide tags',
+    desc: 'Hides tags on individual lists',
+    index: 'hide_tags',
+    includes: ['icheckmovies.com/'],
     excludes: [],
     options: [{
-        name: "enabled",
-        desc: "Enabled",
-        type: "checkbox",
+        name: 'enabled',
+        desc: 'Enabled',
+        type: 'checkbox',
         default: false
     }, {
-        name: "show_hover",
-        desc: "Show tags when moving the cursor over a movie",
-        type: "checkbox",
+        name: 'show_hover',
+        desc: 'Show tags when moving the cursor over a movie',
+        type: 'checkbox',
         default: false
     }]
 };
@@ -1289,51 +1289,51 @@ ICM_WatchlistTab.prototype.Attach = function() {
         return;
     }
 
-    var $movies = $("#itemListMovies");
+    var $movies = $('#itemListMovies');
     if ($movies.length === 0) {
         return;
     }
 
-    var watch_count = $movies.children("li.watch").length;
-    var tabHtml = "<li id=\"listFilterWatch\" class=\"topListMoviesFilter\">" +
-        "<a id=\"linkListFilterWatch\" href=\"#\" title=\"View all your watchlist movies\">Watchlist " +
-        "<span id=\"topListMoviesWatchCount\">(" + watch_count + ")</span></a>" +
-        "</li>";
+    var watch_count = $movies.children('li.watch').length;
+    var tabHtml = '<li id="listFilterWatch" class="topListMoviesFilter">' +
+        '<a id="linkListFilterWatch" href="#" title="View all your watchlist movies">Watchlist ' +
+        '<span id="topListMoviesWatchCount">(' + watch_count + ')</span></a>' +
+        '</li>';
 
-    $("#listFilterUnchecked").after(tabHtml);
+    $('#listFilterUnchecked').after(tabHtml);
 
-    var $first = $("#listFilterMovies").find("a");
-    $first.text($first.text().replace(" movies", ""));
+    var $first = $('#listFilterMovies').find('a');
+    $first.text($first.text().replace(' movies', ''));
 
     // move the order by and views to filter box
-    if ($("#orderByAndView").length === 0) {
-        $("#topList").append('<div id="orderByAndView" style="z-index:200;position:absolute;top:30px;right:0;width:300px;height:20px"> </div>');
-        $("#listOrdering").detach().appendTo("#orderByAndView");
-        $("#listViewswitch").detach().appendTo("#orderByAndView");
+    if ($('#orderByAndView').length === 0) {
+        $('#topList').append('<div id="orderByAndView" style="z-index:200;position:absolute;top:30px;right:0;width:300px;height:20px"> </div>');
+        $('#listOrdering').detach().appendTo('#orderByAndView');
+        $('#listViewswitch').detach().appendTo('#orderByAndView');
     }
 
-    $("#linkListFilterWatch").on("click", function() {
-        $movies = $("#itemListMovies");
-        $movies.children("li").hide();
-        $movies.children("li.watch").show();
+    $('#linkListFilterWatch').on('click', function() {
+        $movies = $('#itemListMovies');
+        $movies.children('li').hide();
+        $movies.children('li.watch').show();
 
-        $(".tabMenu", "#itemContainer").children("li").removeClass("active");
-        $(this).parent("li").addClass("active");
+        $('.tabMenu', '#itemContainer').children('li').removeClass('active');
+        $(this).parent('li').addClass('active');
 
         return false;
     });
 };
 
 ICM_WatchlistTab.prototype.settings = {
-    title: "Watchlist tab",
-    desc: "Creates a tab on lists that shows watchlist entries.",
-    index: "watchlist_tab",
-    includes: ["icheckmovies.com/lists"],
+    title: 'Watchlist tab',
+    desc: 'Creates a tab on lists that shows watchlist entries.',
+    index: 'watchlist_tab',
+    includes: ['icheckmovies.com/lists'],
     excludes: [],
     options: [{
-        name: "enabled",
-        desc: "Enabled",
-        type: "checkbox",
+        name: 'enabled',
+        desc: 'Enabled',
+        type: 'checkbox',
         default: false
     }]
 };
@@ -1351,105 +1351,105 @@ ICM_Owned.prototype.Attach = function() {
         return;
     }
 
-    var $movielist = $("#itemListMovies"),
-        $markOwned = $(".optionMarkOwned");
+    var $movielist = $('#itemListMovies'),
+        $markOwned = $('.optionMarkOwned');
     // Check if 'owned' button exists
     if (!$markOwned.length) {
         return;
     }
 
     if (this.config.free_account) {
-        var owned = evalOrParse(GM_getValue("owned_movies", "[]")),
+        var owned = evalOrParse(GM_getValue('owned_movies', '[]')),
             onListPage = $movielist.length !== 0;
 
         // mark owned movies as owned
         $markOwned.each(function() {
-            var $checkbox = $(this).closest(".optionIconMenu").prev(".checkbox"),
+            var $checkbox = $(this).closest('.optionIconMenu').prev('.checkbox'),
                 $movie = $checkbox.parent(),
-                movie_id = $checkbox.attr("id").replace("check", "movie"),
+                movie_id = $checkbox.attr('id').replace('check', 'movie'),
                 ind = owned.indexOf(movie_id);
 
             // if movie id is found in cached owned movies
             if (ind !== -1) {
-                $movie.toggleClass("notowned owned");
+                $movie.toggleClass('notowned owned');
             }
 
             // remove paid feature crap
-            $(this).removeClass("paidFeature");
+            $(this).removeClass('paidFeature');
         });
 
-        $(".optionMarkOwned").on("click", function() {
-            owned = evalOrParse(GM_getValue("owned_movies", "[]"));
+        $('.optionMarkOwned').on('click', function() {
+            owned = evalOrParse(GM_getValue('owned_movies', '[]'));
 
-            var $checkbox = $(this).closest(".optionIconMenu").prev(".checkbox"),
+            var $checkbox = $(this).closest('.optionIconMenu').prev('.checkbox'),
                 $movie = $checkbox.parent(),
-                movie_id = $checkbox.attr("id").replace("check", "movie"),
+                movie_id = $checkbox.attr('id').replace('check', 'movie'),
                 ind = owned.indexOf(movie_id);
 
             // if movie id is found in cached owned movies
-            console.log((ind !== -1 ? "removing" : "storing") + " " + movie_id);
+            console.log((ind !== -1 ? 'removing' : 'storing') + ' ' + movie_id);
             if (ind !== -1) {
                 owned.splice(ind, 1);
             } else {
                 owned.push(movie_id);
             }
-            $movie.toggleClass("notowned owned");
+            $movie.toggleClass('notowned owned');
 
             if (onListPage) {
-                var owned_count = $movielist.children("li.owned").length;
-                $("#topListMoviesOwnedCount").text("(" + owned_count + ")");
+                var owned_count = $movielist.children('li.owned').length;
+                $('#topListMoviesOwnedCount').text('(' + owned_count + ')');
             }
 
-            GM_setValue("owned_movies", JSON.stringify(owned));
+            GM_setValue('owned_movies', JSON.stringify(owned));
 
             return false;
         });
     }
 
-    var owned_count = $movielist.children("li.owned").length;
+    var owned_count = $movielist.children('li.owned').length;
     var tabHtml = '<li id="listFilterOwned" class="topListMoviesFilter">' +
         '<a id="linkListFilterOwned" href="#" title="View all your owned movies">Owned ' +
         '<span id="topListMoviesOwnedCount">(' + owned_count + ')</span></a>' + '</li>';
 
-    $("#listFilterNew").before(tabHtml);
+    $('#listFilterNew').before(tabHtml);
 
-    var $first = $("#listFilterMovies").find("a");
-    $first.text($first.text().replace(" movies", ""));
+    var $first = $('#listFilterMovies').find('a');
+    $first.text($first.text().replace(' movies', ''));
 
     // move the order by and views to filter box
-    if (!$("#orderByAndView").length && $("#topList").length) {
-        $("#topList").append('<div id="orderByAndView" style="z-index:200;position:absolute;top:30px;right:0;width:300px;height:20px"> </div>');
-        $("#listOrdering").detach().appendTo("#orderByAndView");
-        $("#listViewswitch").detach().appendTo("#orderByAndView");
+    if (!$('#orderByAndView').length && $('#topList').length) {
+        $('#topList').append('<div id="orderByAndView" style="z-index:200;position:absolute;top:30px;right:0;width:300px;height:20px"> </div>');
+        $('#listOrdering').detach().appendTo('#orderByAndView');
+        $('#listViewswitch').detach().appendTo('#orderByAndView');
     }
 
-    $("#linkListFilterOwned, #listFilterOwned").on("click", function() {
-        $movielist = $("#itemListMovies");
-        $movielist.children("li").hide();
-        $movielist.children("li.owned").show();
+    $('#linkListFilterOwned, #listFilterOwned').on('click', function() {
+        $movielist = $('#itemListMovies');
+        $movielist.children('li').hide();
+        $movielist.children('li.owned').show();
 
-        $(".tabMenu", "#itemContainer").children("li").removeClass("active");
-        $(this).parent("li").addClass("active");
+        $('.tabMenu', '#itemContainer').children('li').removeClass('active');
+        $(this).parent('li').addClass('active');
 
         return false;
     });
 };
 
 ICM_Owned.prototype.settings = {
-    title: "Owned tab",
-    desc: "Creates a tab on lists that shows owned entries. Emulates the paid feature",
-    index: "owned_tab",
-    includes: ["icheckmovies.com/"],
+    title: 'Owned tab',
+    desc: 'Creates a tab on lists that shows owned entries. Emulates the paid feature',
+    index: 'owned_tab',
+    includes: ['icheckmovies.com/'],
     excludes: [],
     options: [{
-        name: "enabled",
-        desc: "Enabled",
-        type: "checkbox",
+        name: 'enabled',
+        desc: 'Enabled',
+        type: 'checkbox',
         default: false
     }, {
-        name: "free_account",
-        desc: "I have a free account (must uncheck if you have a paid account)",
-        type: "checkbox",
+        name: 'free_account',
+        desc: 'I have a free account (must uncheck if you have a paid account)',
+        type: 'checkbox',
         default: false
     }]
 };
@@ -1475,20 +1475,20 @@ ICM_LargeList.prototype.Attach = function() {
         // create link
         var link = '<span style="float: right; margin-left: 15px"><a id="icme_large_posters" href="#">Large posters</a></span>';
 
-        if ( $("div#list_container").length !== 1 ) {
+        if ( $('div#list_container').length !== 1 ) {
             var container = '<div id="list_container" style="height: 35px; position: relative">' + link + '</div>';
 
-            $("#movies").parent().before( container );
+            $('#movies').parent().before( container );
         } else {
-            if ($("#list_container").find("p").length === 1) {
-                $("#list_container p:first").append("<span> &mdash; </span>" + link);
+            if ($('#list_container').find('p').length === 1) {
+                $('#list_container p:first').append('<span> &mdash; </span>' + link);
             } else {
-                $("div#list_container").append( link );
+                $('div#list_container').append( link );
             }
         }
 
         var _t = this;
-        $("#icme_large_posters").on("click", function(e) {
+        $('#icme_large_posters').on('click', function(e) {
             e.preventDefault();
 
             _t.load();
@@ -1503,56 +1503,56 @@ ICM_LargeList.prototype.load = function() {
 
     this.loaded = true;
 
-    var style = "#itemListMovies > .listItem { float:left !important; height: 330px !important; width: 255px !important; }" +
-        ".listItem .listImage { float:none !important; width: 230px !important; height: 305px !important; left:-18px !important; top:-18px !important; margin:0!important }" +
-        ".listImage a {width:100% !important; height:100% !important; background: url(\"/images/dvdCover.png\") no-repeat scroll center center transparent !important;}" +
-        ".listImage .coverImage { width:190px !important; height:258px !important; top:21px !important; left: 19px !important; right:auto !important; }" +
-        ".listItem .rank { top: 15px !important; position:absolute !important; height:auto !important; width:65px !important; right:0 !important; margin:0 !important; font-size:30px !important }" +
-        ".listItem .rank .positiondifference span { font-size: 12px !important }" +
-        ".listItem h2 { z-index:11 !important; font-size:14px !important; width:100% !important; margin:-30px 0 0 0 !important; }" +
-        ".listItem .info { font-size:12px !important; width:100% !important; height:auto !important; line-height:16px !important; margin-top:4px !important }" +
-        ".checkbox { top:85px !important; right:12px !important }" +
-        "#itemListMovies .optionIconMenu { top:120px !important; right:20px !important }" +
-        "#itemListMovies .optionIconMenu li { display: block !important }" +
-        "#itemListMovies .optionIconMenuCheckbox { right:20px !important }";
+    var style = '#itemListMovies > .listItem { float:left !important; height: 330px !important; width: 255px !important; }' +
+        '.listItem .listImage { float:none !important; width: 230px !important; height: 305px !important; left:-18px !important; top:-18px !important; margin:0!important }' +
+        '.listImage a {width:100% !important; height:100% !important; background: url("/images/dvdCover.png") no-repeat scroll center center transparent !important;}' +
+        '.listImage .coverImage { width:190px !important; height:258px !important; top:21px !important; left: 19px !important; right:auto !important; }' +
+        '.listItem .rank { top: 15px !important; position:absolute !important; height:auto !important; width:65px !important; right:0 !important; margin:0 !important; font-size:30px !important }' +
+        '.listItem .rank .positiondifference span { font-size: 12px !important }' +
+        '.listItem h2 { z-index:11 !important; font-size:14px !important; width:100% !important; margin:-30px 0 0 0 !important; }' +
+        '.listItem .info { font-size:12px !important; width:100% !important; height:auto !important; line-height:16px !important; margin-top:4px !important }' +
+        '.checkbox { top:85px !important; right:12px !important }' +
+        '#itemListMovies .optionIconMenu { top:120px !important; right:20px !important }' +
+        '#itemListMovies .optionIconMenu li { display: block !important }' +
+        '#itemListMovies .optionIconMenuCheckbox { right:20px !important }';
 
     GM_addStyle(style);
 
-    var $c = $("#itemListMovies").find("div.coverImage").hide();
+    var $c = $('#itemListMovies').find('div.coverImage').hide();
     for (var i = 0; i < $c.length; i++) {
         var cururl = $c[i].style.backgroundImage;
-        if (cururl.substr(4, 1) !== "h") {
-            cururl = cururl.slice(5, -2).replace("small", "medium").replace("Small", "Medium");
+        if (cururl.substr(4, 1) !== 'h') {
+            cururl = cururl.slice(5, -2).replace('small', 'medium').replace('Small', 'Medium');
         } else { // chrome handles urls differently
-            cururl = cururl.slice(4, -1).replace("small", "medium").replace("Small", "Medium");
+            cururl = cururl.slice(4, -1).replace('small', 'medium').replace('Small', 'Medium');
         }
-        var img = document.createElement("img");
-        img.src = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAMSURBVBhXY5j8rA8ABBcCCCnPKCcAAAAASUVORK5CYII=";
-        img.className = "coverImage";
-        img.setAttribute("data-original", cururl);
+        var img = document.createElement('img');
+        img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAMSURBVBhXY5j8rA8ABBcCCCnPKCcAAAAASUVORK5CYII=';
+        img.className = 'coverImage';
+        img.setAttribute('data-original', cururl);
         $c[i].parentNode.appendChild(img);
     }
 
-    $("img.coverImage").lazyload({ threshold : 200 });
+    $('img.coverImage').lazyload({ threshold : 200 });
 };
 
 ICM_LargeList.prototype.settings = {
-    title: "Large posters",
-    desc: "Display large posters on individual lists (large posters are lazy loaded)",
-    index: "large_lists",
-    includes: ["icheckmovies\\.com/lists/(.+)/(.*)"],
-    excludes: ["icheckmovies\\.com/lists/favorited",
-               "icheckmovies\\.com/lists/disliked",
-               "icheckmovies\\.com/lists/watchlist"],
+    title: 'Large posters',
+    desc: 'Display large posters on individual lists (large posters are lazy loaded)',
+    index: 'large_lists',
+    includes: ['icheckmovies\\.com/lists/(.+)/(.*)'],
+    excludes: ['icheckmovies\\.com/lists/favorited',
+               'icheckmovies\\.com/lists/disliked',
+               'icheckmovies\\.com/lists/watchlist'],
     options: [{
-        name: "enabled",
-        desc: "Enabled",
-        type: "checkbox",
+        name: 'enabled',
+        desc: 'Enabled',
+        type: 'checkbox',
         default: true
     }, {
-        name: "autoload",
-        desc: "Autoload",
-        type: "checkbox",
+        name: 'autoload',
+        desc: 'Autoload',
+        type: 'checkbox',
         default: false
     }]
 };
@@ -1574,8 +1574,8 @@ ICM_ListOverviewSort.prototype.Attach = function() {
         GM_addStyle('.itemList .listItem.listItemProgress { float: none !important; }');
     }
 
-    var order = this.config.order === true ? "desc" : "asc";
-    this.Rearrange(order, "all");
+    var order = this.config.order === true ? 'desc' : 'asc';
+    this.Rearrange(order, 'all');
 
     var _t = this;
     $('#progressFilter a').not('#progressFilter-all').one('click', function() {
@@ -1585,17 +1585,17 @@ ICM_ListOverviewSort.prototype.Attach = function() {
 };
 
 ICM_ListOverviewSort.prototype.Rearrange = function(order, section) {
-    var $toplist_list = $("#progress" + section),
-        $toplist_items = $toplist_list.children("li").detach(),
+    var $toplist_list = $('#progress' + section),
+        $toplist_items = $toplist_list.children('li').detach(),
         isInterweaved = true;
 
-    if ( this.config.hide_imdb && section === "all") {
+    if ( this.config.hide_imdb && section === 'all') {
         if (this.config.autosort) {
-            $toplist_items = $toplist_items.not(".imdb");
+            $toplist_items = $toplist_items.not('.imdb');
             // list would be sorted anyway, but until then the order is incorrect
         } else {
             // preserve original order
-            $toplist_items = $(this.Straighten($toplist_items.toArray())).not(".imdb");
+            $toplist_items = $(this.Straighten($toplist_items.toArray())).not('.imdb');
             isInterweaved = false;
         }
     }
@@ -1604,12 +1604,12 @@ ICM_ListOverviewSort.prototype.Rearrange = function(order, section) {
 
     if (this.config.autosort) {
         var lookup_map = toplist_arr.map(function(item, i) {
-            var width = $(item).find("span.progress").css("width").replace("px", "");
+            var width = $(item).find('span.progress').css('width').replace('px', '');
             return {index: i, value: parseFloat(width)};
         });
 
         lookup_map.sort(function(a, b) {
-            return (order === "asc" ? 1 : -1) *
+            return (order === 'asc' ? 1 : -1) *
                 (a.value > b.value ? 1 : -1);
         });
 
@@ -1670,40 +1670,40 @@ function test(arr) {
 test(a) && test(b) */
 
 ICM_ListOverviewSort.prototype.settings = {
-    title: "Progress page",
-    desc: "Change the order of lists on the progress page",
-    index: "toplists_sort",
-    includes: ["icheckmovies.com/profiles/progress"],
+    title: 'Progress page',
+    desc: 'Change the order of lists on the progress page',
+    index: 'toplists_sort',
+    includes: ['icheckmovies.com/profiles/progress'],
     excludes: [],
     options: [{
-        name: "enabled",
-        desc: "Enabled",
-        type: "checkbox",
+        name: 'enabled',
+        desc: 'Enabled',
+        type: 'checkbox',
         default: false
     }, {
-        name: "autosort",
-        desc: "Sort lists by completion rate",
-        type: "checkbox",
+        name: 'autosort',
+        desc: 'Sort lists by completion rate',
+        type: 'checkbox',
         default: true
     }, {
-        name: "order",
-        desc: "Descending",
-        type: "checkbox",
+        name: 'order',
+        desc: 'Descending',
+        type: 'checkbox',
         default: true
     }, {
-        name: "single_col",
-        desc: "Single column",
-        type: "checkbox",
+        name: 'single_col',
+        desc: 'Single column',
+        type: 'checkbox',
         default: false
     }, {
-        name: "icebergs",
-        desc: "Fill columns from left to right",
-        type: "checkbox",
+        name: 'icebergs',
+        desc: 'Fill columns from left to right',
+        type: 'checkbox',
         default: false
     }, {
-        name: "hide_imdb",
-        desc: "Hide IMDb lists from \"All\" tab",
-        type: "checkbox",
+        name: 'hide_imdb',
+        desc: 'Hide IMDb lists from "All" tab',
+        type: 'checkbox',
         default: false
     }]
 };
@@ -1715,7 +1715,7 @@ ICM_ListsTabDisplay.prototype.constructor = ICM_ListsTabDisplay;
 function ICM_ListsTabDisplay(config) {
     ICM_BaseFeature.call(this, config);
 
-    this.block = $("#itemListToplists");
+    this.block = $('#itemListToplists');
     this.sep = '<li class="groupSeparator"><br><hr><br></li>';
     // multiline regex that leaves only list name, excl. a common beginning and parameters
     this.reURL = /^[ \t]*(?:https?:\/\/)?(?:www\.)?(?:icheckmovies.com)?\/?(?:lists)?\/?([^\s\?]+\/)(?:\?.+)?[ \t]*$/gm;
@@ -1730,7 +1730,7 @@ ICM_ListsTabDisplay.prototype.Attach = function() {
 
         if (_c.sort_official) {
             var officialLists = lists
-                .has("ul.tagList a[href$='user%3Aicheckmovies']")
+                .has('ul.tagList a[href$="user%3Aicheckmovies"]')
                 .filter(function() {
                     // icm bug: deleted lists reset to icheckmovies user
                     return !$(this).find('.title').attr('href').endsWith('//');
@@ -1740,7 +1740,7 @@ ICM_ListsTabDisplay.prototype.Attach = function() {
 
         if (_c.sort_groups) {
             var _t = this;
-            ["group1", "group2"].forEach(function(group) {
+            ['group1', 'group2'].forEach(function(group) {
                 var stored = _c[group];
                 if (typeof stored === 'string') {
                     // Parse textarea content
@@ -1776,7 +1776,7 @@ ICM_ListsTabDisplay.prototype.Attach = function() {
 
 ICM_ListsTabDisplay.prototype.move = function(lists) {
     if (lists.length) {
-        var target = this.block.find("li.groupSeparator").last();
+        var target = this.block.find('li.groupSeparator').last();
         if (target.length) {
             target.after(lists, this.sep);
         } else {
@@ -1788,7 +1788,7 @@ ICM_ListsTabDisplay.prototype.move = function(lists) {
 ICM_ListsTabDisplay.prototype.getLists = function(listIDs) {
     if (listIDs.length) {
         var selected = this.block.children().filter(function() {
-            var href = $(this).find("a.title").attr("href");
+            var href = $(this).find('a.title').attr('href');
             return href && $.inArray(href.substring(7), listIDs) !== -1; // sep matches too
         });
         return selected;
@@ -1797,44 +1797,44 @@ ICM_ListsTabDisplay.prototype.getLists = function(listIDs) {
 };
 
 ICM_ListsTabDisplay.prototype.settings = {
-    title: "Lists tab display",
-    desc: "Organize movie info tab with all lists (\/movies\/*\/rankings\/, <a href=\"/movies/pulp+fiction/rankings/\">example</a>)",
-    index: "lists_tab_display",
-    includes: ["icheckmovies.com/lists/(.+)",
-               "icheckmovies.com/search/movies/(.+)",
-               "icheckmovies.com/movies/.+/rankings/(.*)",
-               "icheckmovies.com/movies/[^/]*$", // list of all movies
-               "icheckmovies.com/movies/((un)?checked|favorited|disliked|owned|watchlist|recommended)/"],
+    title: 'Lists tab display',
+    desc: 'Organize movie info tab with all lists (\/movies\/*\/rankings\/, <a href="/movies/pulp+fiction/rankings/">example</a>)',
+    index: 'lists_tab_display',
+    includes: ['icheckmovies.com/lists/(.+)',
+               'icheckmovies.com/search/movies/(.+)',
+               'icheckmovies.com/movies/.+/rankings/(.*)',
+               'icheckmovies.com/movies/[^/]*$', // list of all movies
+               'icheckmovies.com/movies/((un)?checked|favorited|disliked|owned|watchlist|recommended)/'],
     excludes: [],
     options: [{
-        name: "redirect",
-        desc: "Redirect \"in # lists\" movie links to \"All\" lists tab",
-        type: "checkbox",
+        name: 'redirect',
+        desc: 'Redirect "in # lists" movie links to "All" lists tab',
+        type: 'checkbox',
         default: true
     }, {
-        name: "sort_official",
-        desc: "Auto-sort official lists",
-        type: "checkbox",
+        name: 'sort_official',
+        desc: 'Auto-sort official lists',
+        type: 'checkbox',
         default: true
     }, {
-        name: "sort_filmos",
-        desc: "Auto-sort filmographies",
-        type: "checkbox",
+        name: 'sort_filmos',
+        desc: 'Auto-sort filmographies',
+        type: 'checkbox',
         default: true
     }, {
-        name: "sort_groups",
-        desc: "Auto-sort lists from user defined groups",
-        type: "checkbox",
+        name: 'sort_groups',
+        desc: 'Auto-sort lists from user defined groups',
+        type: 'checkbox',
         default: true
     }, {
-        name: "group1",
-        desc: "Group 1",
-        type: "textarea",
+        name: 'group1',
+        desc: 'Group 1',
+        type: 'textarea',
         default: []
     }, {
-        name: "group2",
-        desc: "Group 2",
-        type: "textarea",
+        name: 'group2',
+        desc: 'Group 2',
+        type: 'textarea',
         default: []
     }]
 };
@@ -1855,13 +1855,13 @@ ICM_ExportLists.prototype.Attach = function() {
 
     var sep = _c.delimiter;
 
-    $(".optionExport").one("click", function() {
+    $('.optionExport').one('click', function() {
         if (sep !== ',' && sep !== ';') {
             sep = '\t';
         }
 
-        var data =  ["rank", "title", "aka", "year", "official_toplists",
-            "checked", "favorite", "dislike", "imdb"].join(sep) + sep + '\n';
+        var data =  ['rank', 'title', 'aka', 'year', 'official_toplists',
+            'checked', 'favorite', 'dislike', 'imdb'].join(sep) + sep + '\n';
 
         var encode_field = function(field) {
             return field.indexOf('"') !== -1 || field.indexOf(sep) !== -1 ?
@@ -1869,17 +1869,17 @@ ICM_ExportLists.prototype.Attach = function() {
                    field;
         };
 
-        $("#itemListMovies > li").each(function() {
+        $('#itemListMovies > li').each(function() {
             var item = $(this),
-                rank = item.find(".rank").text().trim().replace(/ .+/, ''),
-                title = encode_field(item.find("h2>a").text()),
-                aka = encode_field(item.find(".info > em").text()),
-                year = item.find(".info a:first").text(),
-                toplists = parseInt(item.find(".info a:last").text(), 10),
-                checked = item.hasClass("checked") ? 'yes' : 'no',
-                isFav = item.hasClass("favorite") ? 'yes' : 'no',
-                isDislike = item.hasClass("hated") ? 'yes' : 'no',
-                imdburl = item.find(".optionIMDB").attr("href"),
+                rank = item.find('.rank').text().trim().replace(/ .+/, ''),
+                title = encode_field(item.find('h2>a').text()),
+                aka = encode_field(item.find('.info > em').text()),
+                year = item.find('.info a:first').text(),
+                toplists = parseInt(item.find('.info a:last').text(), 10),
+                checked = item.hasClass('checked') ? 'yes' : 'no',
+                isFav = item.hasClass('favorite') ? 'yes' : 'no',
+                isDislike = item.hasClass('hated') ? 'yes' : 'no',
+                imdburl = item.find('.optionIMDB').attr('href'),
                 line = [rank, title, aka, year, toplists, checked,
                     isFav, isDislike, imdburl].join(sep) + sep + '\n';
             data += line;
@@ -1887,9 +1887,9 @@ ICM_ExportLists.prototype.Attach = function() {
 
         // BOM with ; or , as separator and without sep= - for Excel
         var bom = _c.bom ? '\uFEFF' : '',
-            dataURI = "data:text/csv;charset=utf-8," + bom + encodeURIComponent(data);
+            dataURI = 'data:text/csv;charset=utf-8,' + bom + encodeURIComponent(data);
         // link swapping with a correct filename - http://caniuse.com/download
-        $(this).attr("href", dataURI).attr("download", $("#topList>h1").text() + ".csv");
+        $(this).attr('href', dataURI).attr('download', $('#topList>h1').text() + '.csv');
 
         // after changing URL jQuery fires a default click event
         // on the link user clicked on, and loads dataURI as URL (!)
@@ -1899,25 +1899,25 @@ ICM_ExportLists.prototype.Attach = function() {
 };
 
 ICM_ExportLists.prototype.settings = {
-    title: "Export lists",
-    desc: "Download any list as .csv (doesn't support search results). Emulates the paid feature, so don't enable it if you have a paid account",
-    index: "export_lists",
-    includes: ["icheckmovies.com/lists/(.+)"],
+    title: 'Export lists',
+    desc: 'Download any list as .csv (doesn\'t support search results). Emulates the paid feature, so don\'t enable it if you have a paid account',
+    index: 'export_lists',
+    includes: ['icheckmovies.com/lists/(.+)'],
     excludes: [],
     options: [{
-        name: "enabled",
-        desc: "Enabled",
-        type: "checkbox",
+        name: 'enabled',
+        desc: 'Enabled',
+        type: 'checkbox',
         default: false
     }, {
-        name: "delimiter",
-        desc: "Use as delimiter (accepts ';' or ','; otherwise uses \\t)",
-        type: "textinput",
+        name: 'delimiter',
+        desc: 'Use as delimiter (accepts \';\' or \',\'; otherwise uses \\t)',
+        type: 'textinput',
         default: ';'
     }, {
-        name: "bom",
-        desc: "Include BOM (required for Excel)",
-        type: "checkbox",
+        name: 'bom',
+        desc: 'Include BOM (required for Excel)',
+        type: 'checkbox',
         default: true
     }]
 };
@@ -1944,7 +1944,7 @@ ICM_ProgressTopX.prototype.Attach = function() {
 
 ICM_ProgressTopX.prototype.addStats = function(event) {
     var targetPage = parseInt(event.data.cfg.target_page, 10), // * 25 = target rank
-        lists = $(".itemListCompact[id^='progress']:visible span.rank a");
+        lists = $('.itemListCompact[id^="progress"]:visible span.rank a');
 
     lists.each(function() {
         var list = $(this),
@@ -1955,7 +1955,7 @@ ICM_ProgressTopX.prototype.addStats = function(event) {
             return;
         }
 
-        var url = list.attr("href").replace(/=.*$/, "=" + targetPage),
+        var url = list.attr('href').replace(/=.*$/, '=' + targetPage),
             progress = parseInt(list.parent().text().match(/\d+/), 10);
 
         $.get(url, function(data) {
@@ -1963,8 +1963,8 @@ ICM_ProgressTopX.prototype.addStats = function(event) {
             if (data) {
                 var minchecks = parseInt(data[0], 10),
                     dif = minchecks - progress;
-                list.text(oldText + " - " + minchecks + " req - " + dif + " dif");
-                list.attr("href", url);
+                list.text(oldText + ' - ' + minchecks + ' req - ' + dif + ' dif');
+                list.attr('href', url);
             }
         });
     });
@@ -1973,20 +1973,20 @@ ICM_ProgressTopX.prototype.addStats = function(event) {
 };
 
 ICM_ProgressTopX.prototype.settings = {
-    title: "Progress top X",
-    desc: "Find out how many checks you need to get into Top 25/50/100/1000/...",
-    index: "progress_top_x",
-    includes: ["icheckmovies.com/profiles/progress/"],
+    title: 'Progress top X',
+    desc: 'Find out how many checks you need to get into Top 25/50/100/1000/...',
+    index: 'progress_top_x',
+    includes: ['icheckmovies.com/profiles/progress/'],
     excludes: [],
     options: [{
-        name: "enabled",
-        desc: "Enabled",
-        type: "checkbox",
+        name: 'enabled',
+        desc: 'Enabled',
+        type: 'checkbox',
         default: true
     }, {
-        name: "target_page",
-        desc: "Ranking page you want to be on (page x 25 = rank)",
-        type: "textinput",
+        name: 'target_page',
+        desc: 'Ranking page you want to be on (page x 25 = rank)',
+        type: 'textinput',
         default: '40'
     }]
 };

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -1229,7 +1229,13 @@ ListCrossCheck.prototype.outputMovies = function() {
                 data += line;
             }
 
-            window.location.href = 'data:text/csv;charset=utf-8,' + encodeURIComponent(data);
+            // This should use window instead of unsafeWindow, but
+            // FF 39.0.3 broke changing window.location in GM sandbox.
+            // When they fix that, either revert back to window
+            // or re-use code from ExportLists.
+            // https://bugzilla.mozilla.org/show_bug.cgi?id=1192821
+            // https://github.com/greasemonkey/greasemonkey/issues/2232
+            unsafeWindow.location.href = 'data:text/csv;charset=utf-8,' + encodeURIComponent(data);
         });
     } else {
         $('#icme-crossref-notfound').remove();

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -40,7 +40,7 @@ function setProperty(path, obj, val) {
 
     while ((part = parts.shift())) { // assignment
         // rewrite property if it exists but is not an object
-        obj = obj[part] = (obj[part] instanceof Object) ?
+        obj = obj[part] = obj[part] instanceof Object ?
                           obj[part] : {};
     }
 
@@ -89,7 +89,7 @@ ICM_BaseFeature.prototype.updateConfig = function(config) {
     $.each(this.settings.options, function(i, option) {
         var idx = option.name,
             oldValue = config.Get(module + '.' + idx),
-            newValue = (oldValue !== undefined) ? oldValue : option.default;
+            newValue = oldValue !== undefined ? oldValue : option.default;
 
         setProperty(idx, cur, newValue);
     });
@@ -153,7 +153,7 @@ ICM_Config.prototype.Toggle = function( index ) {
     if ( val === true || val === false ) {
         changeVal = !val;
     } else if ( val === "asc" || val === "desc" ) {
-        changeVal = (val === "asc" ? "desc" : "asc");
+        changeVal = val === "asc" ? "desc" : "asc";
     } else {
         return false; // Couldn't toggle a value
     }
@@ -410,7 +410,7 @@ ICM_UpcomingAwardsList.prototype.Attach = function() {
         var abs = this.config.show_absolute;
         var get_span = function(award, cutoff) {
             var num = Math.ceil(total_items * cutoff) - checks;
-            if ((!abs) && (num <= 0))
+            if (!abs && num <= 0)
                 return '';
             return '<span style="margin-left: 30px">' + award + ': <b>' + num + '</b></span>';
         };
@@ -495,7 +495,7 @@ ICM_UpcomingAwardsOverview.prototype.PopulateLists = function() {
         sel = {progress: {rank: "span.rank", title: "h3 > a"},
                lists: {rank: "span.info > strong:first", title: "h2 > a.title"}},
         // use different selectors depending on page
-        curSel = (location.href.indexOf("progress") !== -1) ?
+        curSel = location.href.indexOf("progress") !== -1 ?
                  sel.progress : sel.lists,
         award_types = [['Platinum', 1], ['Gold', 0.9], ['Silver', 0.75], ['Bronze', 0.5]];
 
@@ -558,7 +558,7 @@ ICM_UpcomingAwardsOverview.prototype.HTMLOut = function() {
         var el = this.lists[i],
             unhide_icon = '<img title="Unhide ' + el.list_title + '" alt="Unhide icon" src="' + unhide_icon_data + '">',
             hide_icon = '<img title="Hide ' + el.list_title + '" alt="Hide icon" src="' + hide_icon_data + '">',
-            is_hidden = (this.hidden_lists.indexOf(el.list_url) !== -1);
+            is_hidden = this.hidden_lists.indexOf(el.list_url) !== -1;
 
         list_table  += '<tr class="' + (is_hidden ? "hidden-list" : "") +
             '" data-award-type="' + el.award_type + '" data-list-url="' + el.list_url + '">' +
@@ -915,7 +915,7 @@ ICM_ListCrossCheck.prototype.GetUncheckedFilms = function(list_elem) {
     $.get(url, function(response) {
         $(list_elem).removeClass("icme_listcc_selected icme_listcc_pending").find("span.percentage").show();
 
-        var filter = (_t.config.checks) ? "" : "li.unchecked";
+        var filter = _t.config.checks ? "" : "li.unchecked";
         // the site returns html with extra whitespace
         var unchecked = $($.parseHTML(response)).find("ol#itemListMovies").children(filter);
 
@@ -968,7 +968,7 @@ ICM_ListCrossCheck.prototype.UpdateMovies = function(content) {
         if ( !found ) {
             // add it to the main movies array only if the script is not checking for matches on all top lists
             // OR if the script is checking for matches on all top lists, but this is just the first top list
-            if ( !show_perfect_matches || ( show_perfect_matches && this.sequence_number === 1 ) ) {
+            if ( !show_perfect_matches || this.sequence_number === 1 ) {
                 var $item = $(content[i]);
                 $item.find(".rank").html("0");
 
@@ -986,7 +986,7 @@ ICM_ListCrossCheck.prototype.UpdateMovies = function(content) {
         }
     }
 
-    var has_toplists_left = (this.sequence_number < this.toplists.length);
+    var has_toplists_left = this.sequence_number < this.toplists.length;
 
     // if finding movies on all selected top lists
     if ( show_perfect_matches ) {
@@ -1022,7 +1022,7 @@ ICM_ListCrossCheck.prototype.OutputMovies = function() {
 
         if ( limit > 0 ) {
             this.movies = $.grep(this.movies, function(el) {
-                return (el.c >= limit);
+                return el.c >= limit;
             });
         }
     }
@@ -1169,7 +1169,7 @@ ICM_ListCrossCheck.prototype.CreateTab = function() {
 
                 // Make the current tab work if we want to return to it
                 $("ul.tabMenu").children("li").each(function() {
-                    if (!($(this).children("a").length)) {
+                    if (!$(this).children("a").length) {
                         var $clicked = $(this);
                         $clicked.on("click", function() {
                             $("ol#itemListToplists").children("li").show();
@@ -1622,7 +1622,7 @@ ICM_ListOverviewSort.prototype.Rearrange = function(order, section) {
 ICM_ListOverviewSort.prototype.Straighten = function(list) {
     var even_i = [], odd_i = [];
     for (var i = 0; i < list.length; i++) {
-        if ((i % 2) === 0) {
+        if (i % 2 === 0) {
             even_i.push(list[i]);
         } else {
             odd_i.push(list[i]);
@@ -1773,7 +1773,7 @@ ICM_ListsTabDisplay.prototype.getLists = function(listIDs) {
     if (listIDs.length) {
         var selected = this.block.children().filter(function() {
             var href = $(this).find("a.title").attr("href");
-            return (href && ($.inArray(href.substring(7), listIDs) !== -1)); // sep matches too
+            return href && $.inArray(href.substring(7), listIDs) !== -1; // sep matches too
         });
         return selected;
     }
@@ -1848,9 +1848,9 @@ ICM_ExportLists.prototype.Attach = function() {
             "checked", "favorite", "dislike", "imdb"].join(sep) + sep + '\n';
 
         var encode_field = function(field) {
-            return field.indexOf('"') !== -1 || field.indexOf(sep) !== -1
-                   ? '"' + field.replace('"', '""', 'g') + '"'
-                   : field;
+            return field.indexOf('"') !== -1 || field.indexOf(sep) !== -1 ?
+                   '"' + field.replace('"', '""', 'g') + '"' :
+                   field;
         };
 
         $("#itemListMovies > li").each(function() {
@@ -1870,7 +1870,7 @@ ICM_ExportLists.prototype.Attach = function() {
         });
 
         // BOM with ; or , as separator and without sep= - for Excel
-        var bom = (_c.bom) ? '\uFEFF' : '',
+        var bom = _c.bom ? '\uFEFF' : '',
             dataURI = "data:text/csv;charset=utf-8," + bom + encodeURIComponent(data);
         // link swapping with a correct filename - http://caniuse.com/download
         $(this).attr("href", dataURI).attr("download", $("#topList>h1").text() + ".csv");

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -249,18 +249,21 @@ ConfigWindow.prototype.build = function() {
     this.modules.sort(function(a, b) { return a.title > b.title ? 1 : -1; });
 
     // Create and append a new item in the drop down menu under your username
-    var cfgLink = '<li><a id="icm_enhanced_cfg" href="#" title="Configure iCheckMovies Enhanced script options">ICM Enhanced</a></li>';
+    var cfgLink = '<li><a id="icm_enhanced_cfg" href="#"' +
+        'title="Configure iCheckMovies Enhanced script options">ICM Enhanced</a></li>';
 
     $('ul#profileOptions').append( cfgLink );
 
     // Custom CSS for jqmodal
     var customCSS =
-        '.jqmWindow { display: none; position: absolute; font-family: verdana, arial, sans-serif; ' +
+        '.jqmWindow { ' +
+            'display: none; position: absolute; font-family: verdana, arial, sans-serif; ' +
         'background-color:#fff; color:#000; padding: 12px 30px;}' +
         '.jqmOverlay { background-color:#000 }' +
         'div.icme_cfg_feature { margin-bottom: 15px; }' +
         'span.has_settings:hover { text-decoration: underline; }' +
-        'div.icme_cfg_feature > div.icme_cfg_settings { display: none; margin-left: 22px; margin-top: 10px; }' +
+        'div.icme_cfg_feature > div.icme_cfg_settings { ' +
+            'display: none; margin-left: 22px; margin-top: 10px; }' +
         'span.icme_feature_title { font-weight: bold; }' +
         'input[type=text] { font-family: monospace }' +
         '#module_settings { margin:10px 0; }' +
@@ -278,16 +281,19 @@ ConfigWindow.prototype.build = function() {
     moduleList += '</select>';
 
     // HTML for the main jqmodal window
-    var cfgMainHtml =
-        '<div class="jqmWindow" id="cfgModal" style="top: 17%; left: 50%; margin-left: -400px; width: 800px; height:450px">' +
-        '<h3 style="color:#bbb">iCheckMovies Enhanced ' + this.config.cfg.script_config.version + ' configuration</h3>' +
-        moduleList +
-        '<hr><div id="module_settings"></div>' +
-        '<button id="configSave">Save settings</button>' +
+    var ver = this.config.cfg.script_config.version,
+        cfgMainDesc = 'iCheckMovies Enhanced ' + ver + ' configuration',
+        cfgMainHtml = '<div class="jqmWindow" id="cfgModal">' +
+            '<h3 style="color:#bbb">' + cfgMainDesc + '</h3>' +
+            moduleList +
+            '<hr><div id="module_settings"></div>' +
+            '<button id="configSave">Save settings</button>' +
         '</div>';
 
-    // append config window
-    $('body').append( cfgMainHtml );
+    // style & append config window
+    $(cfgMainHtml).css({
+        top: '17%', left: '50%', marginLeft: '-400px', width: '800px', height: '450px'
+    }).appendTo('body');
 
     var _t = this;
 
@@ -337,10 +343,14 @@ function RandomFilmLink(config) {
 // Creates an element and inserts it into the DOM
 RandomFilmLink.prototype.attach = function() {
     if ( this.config.enabled ) {
-        var randomFilm = '<span style="float:right; margin-left: 15px"><a href="#" id="randomFilm">Help me pick a film!</a></span>';
+        var randomFilm =
+            '<span style="float:right; margin-left: 15px">' +
+                '<a href="#" id="randomFilm">Help me pick a film!</a></span>';
 
         if ( $('div#list_container').length !== 1 ) {
-            var container = '<div id="list_container" style="height: 35px; position: relative">' + randomFilm + '</div>';
+            var container =
+                '<div id="list_container" style="height: 35px; position: relative">' +
+                    randomFilm + '</div>';
 
             $('#movies').parent().before( container );
         } else {
@@ -399,7 +409,8 @@ RandomFilmLink.prototype.settings = {
         default: true
     }, {
         name: 'unique',
-        desc: 'Unique suggestions (shows each entry only once until every entry has been shown once)',
+        desc: 'Unique suggestions (shows each entry only once ' +
+              'until every entry has been shown once)',
         type: 'checkbox',
         default: true
     }]
@@ -433,7 +444,9 @@ UpcomingAwardsList.prototype.attach = function() {
                       getSpan('Gold', 0.9) + getSpan('Platinum', 1);
 
         if ( $('div#list_container').length !== 1 ) {
-            var container = '<div id="list_container" style="height: 35px; position: relative">' + statistics + '</div>';
+            var container =
+                '<div id="list_container" style="height: 35px; position: relative">' +
+                    statistics + '</div>';
 
             $('#movies').parent().before( container );
         } else {
@@ -481,8 +494,8 @@ UpcomingAwardsOverview.prototype.attach = function() {
         return;
     }
 
-    var loadLink = $('<p>', {id: 'lad_container'})
-        .append($('<a>', {id: 'load_award_data', href: '#', text: 'Load upcoming awards for this user'}));
+    var loadLink = '<p id="lad_container">' +
+        '<a id="load_award_data" href="#">Load upcoming awards for this user</a></p>';
 
     $('#listOrdering').before(loadLink);
 
@@ -622,31 +635,35 @@ UpcomingAwardsOverview.prototype.htmlOut = function() {
             '<td style="width: 65px">' + el.awardType + '</td>' +
             '<td style="width: 65px">' + el.awardChecks + '</td>' +
             '<td><div style="height: 28px; overflow: hidden">' +
-                '<a class="list-title" href="' + el.listUrl + '">' + el.listTitle + '</a></div></td>' +
-            '<td style="width: 70px"><a href="#" class="icm_toggle_list">' + icon + '</a></td></tr>';
+                '<a class="list-title" href="' + el.listUrl + '">' + el.listTitle + '</a>' +
+            '</div></td>' +
+            '<td style="width: 70px"><a href="#" class="icm_toggle_list">' + icon + '</a>' +
+            '</td></tr>';
     }
 
     listTable += '</tbody></table>';
 
     // build the html...
     var toggleUpcomingLink =
-        '<p id="ua_toggle_link_container" style="position: relative; left:0; top:0; width: 200px">' +
+        '<p id="ua_toggle_link_container" style="position: relative; ' +
+            'left:0; top:0; width: 200px">' +
             '<a id="toggle_upcoming_awards" href="#">' +
                 '<span class="_show" style="display: none">Show upcoming awards</span>' +
-                '<span class="_hide">Hide upcoming awards</span></a></p>';
-    var toggleFullLink =
+                '<span class="_hide">Hide upcoming awards</span></a></p>',
+        toggleFullLink =
         '<a id="toggle_full_list" href="#">' +
             '<span class="_show">Show full list</span>' +
-            '<span class="_hide" style="display: none">Minimize full list</span></a>';
-    var toggleHiddenLink = '<a id="toggle_hidden_list" href="#">Show hidden</a>';
+            '<span class="_hide" style="display: none">Minimize full list</span></a>',
+        toggleHiddenLink = '<a id="toggle_hidden_list" href="#">Show hidden</a>';
 
     var links =
-        '<p id="award_display_links" style="position: absolute; right: 0; top: 0; font-weight: bold">' +
+        '<p id="award_display_links" style="position: absolute; ' +
+            'right: 0; top: 0; font-weight: bold">' +
             'Display: <a id="display_all" href="#">All</a>, ' +
-            '<a id="display_bronze" href="#">Bronze</a>, ' +
-            '<a id="display_silver" href="#">Silver</a>, ' +
-            '<a id="display_gold" href="#">Gold</a>, ' +
-            '<a id="display_platinum" href="#">Platinum</a>, ' +
+            '<a id="display_bronze"   class="display_award" href="#">Bronze</a>, ' +
+            '<a id="display_silver"   class="display_award" href="#">Silver</a>, ' +
+            '<a id="display_gold"     class="display_award" href="#">Gold</a>, ' +
+            '<a id="display_platinum" class="display_award" href="#">Platinum</a>, ' +
             toggleFullLink + ', ' + toggleHiddenLink + '</p>';
 
     var awardContainer =
@@ -722,7 +739,7 @@ UpcomingAwardsOverview.prototype.htmlOut = function() {
         $lists.not('.hidden-list').show();
     });
 
-    $('#award_display_links').on('click', 'a#display_bronze, a#display_silver, a#display_gold, a#display_platinum', function(e) {
+    $('#award_display_links').on('click', 'a.display_award', function(e) {
         e.preventDefault();
 
         var awardType = $(this).attr('id').split('_')[1];
@@ -786,7 +803,8 @@ ListCustomColors.prototype.attach = function() {
                 return;
             }
             var sel = 'ol#itemListMovies li.' + className;
-            listColorsCss += sel + ', ' + sel + ' ul.optionIconMenu { background-color: ' + color + ' !important; }';
+            listColorsCss += sel + ', ' + sel + ' ul.optionIconMenu ' +
+                '{ background-color: ' + color + ' !important; }';
         };
 
         buildCSS('favorite', this.config.colors.favorite);
@@ -799,7 +817,8 @@ ListCustomColors.prototype.attach = function() {
 
 ListCustomColors.prototype.settings = {
     title: 'Custom list colors',
-    desc: 'Changes entry colors on lists to visually separate entries in your favorites/watchlist/dislikes',
+    desc: 'Changes entry colors on lists to visually separate entries ' +
+          'in your favorites/watchlist/dislikes',
     index: 'list_colors',
     includes: ['icheckmovies.com/'],
     excludes: [],
@@ -860,73 +879,82 @@ ListCrossCheck.prototype.init = function() {
 };
 
 ListCrossCheck.prototype.attach = function() {
-    if (this.config.enabled && $('#itemListToplists').length) {
-        var actions = '<div id="crActions" style="margin-bottom: 18px"><button id="cfgListCCActivate">Activate CR</button></div>';
-
-        $('#itemContainer').before(actions);
-
-        var _t = this;
-
-        $('div#crActions').on( 'click', 'button#cfgListCCActivate', function() {
-            $(this).prop('disabled', true);
-
-            _t.createTab();
-
-            _t.activate();
-        });
-
-        var customCSS = '<style type="text/css">' +
-            'ol#itemListToplists li.icme_listcc_selected, ol#itemListToplists li.icme_listcc_hover, ' +
-            '.icme_listcc_selected .progress, .icme_listcc_hover .progress' +
-            ' { background-color: #cccccc !important; }' +
-            'ol#itemListToplists li.icme_listcc_pending, .icme_listcc_pending .progress { background-color: #ffffb2 !important; }' +
-            '</style>';
-
-        $('body').append(customCSS);
+    if (!this.config.enabled || $('#itemListToplists').length === 0) {
+        return;
     }
+
+    var actions = '<div id="crActions" style="margin-bottom: 18px">' +
+        '<button id="cfgListCCActivate">Activate CR</button></div>';
+
+    $('#itemContainer').before(actions);
+    var _t = this;
+
+    $('div#crActions').on( 'click', 'button#cfgListCCActivate', function() {
+        $(this).prop('disabled', true);
+        _t.createTab();
+        _t.activate();
+    });
+
+    var customCSS = '<style type="text/css">' +
+        'ol#itemListToplists li.icme_listcc_selected, ' +
+        'ol#itemListToplists li.icme_listcc_hover, ' +
+        '.icme_listcc_selected .progress, .icme_listcc_hover .progress ' +
+            '{ background-color: #cccccc !important; } ' +
+        'ol#itemListToplists li.icme_listcc_pending, .icme_listcc_pending .progress ' +
+            '{ background-color: #ffffb2 !important; }' +
+        '</style>';
+
+    $('head').append(customCSS);
 };
 
 ListCrossCheck.prototype.activate = function() {
     this.init();
-
     this.activated = true;
-
     var _t = this;
 
-    $('button#cfgListCCActivate').after(' <button id="cfgListCCDeactivate">Deactivate</button>');
+    $('button#cfgListCCActivate')
+        .after('<button id="cfgListCCDeactivate">Deactivate</button>');
 
     $('div#crActions').on('click', 'button#cfgListCCDeactivate', function() {
         _t.deactivate();
-
         $('button#cfgListCCActivate').prop('disabled', false);
     });
 
-    if ( !this.activatedOnce ) { // ff 3.6 compatibility (ff 3.6 fails to unbind the events in all possible ways)
-        $('ol#itemListToplists li').on('click mouseover mouseout', function(e) {
-            if ( _t.activated && !_t.inProgress ) { // ff 3.6 compatibility
-                // these event actions must not work for cloned toplists under the selected tab
-                if ( !$(this).hasClass('icme_listcc') ) {
-                    if ( e.type === 'mouseover' && !$(this).hasClass('icme_listcc_selected') ) {
-                        $(this).addClass('icme_listcc_hover').find('span.percentage').hide();
-                    } else if ( e.type === 'mouseout' && !$(this).hasClass('icme_listcc_selected') ) {
-                        $(this).removeClass('icme_listcc_hover').find('span.percentage').show();
-                    } else if ( e.type === 'click' ) {
-                        $(this).removeClass('icme_listcc_hover');
-
-                        if ( $(this).hasClass('icme_listcc_selected') ) {
-                            $(this).removeClass('icme_listcc_selected').addClass('icme_listcc_hover');
-                        } else {
-                            $(this).addClass('icme_listcc_selected');
-                        }
-                    }
-                }
-
-                return false; // ff 3.6 compatibility
-            }
-        });
-
-        this.activatedOnce = true;
+    // ff 3.6 compatibility (ff 3.6 fails to unbind the events in all possible ways)
+    if (this.activatedOnce) {
+        return;
     }
+
+    $('ol#itemListToplists li').on('click mouseover mouseout', function(e) {
+        var activeAndIdle = _t.activated && !_t.inProgress;
+        if ( !activeAndIdle ) { // ff 3.6 compatibility
+            return;
+        }
+
+        var li = $(this);
+        // event actions must not work for cloned toplists under the selected tab
+        if ( li.hasClass('icme_listcc') ) {
+            return false; // ff 3.6 compatibility
+        }
+
+        var wasSelected = li.hasClass('icme_listcc_selected');
+        if ( e.type === 'mouseover' && !wasSelected ) {
+            li.addClass('icme_listcc_hover').find('span.percentage').hide();
+        } else if ( e.type === 'mouseout' && !wasSelected ) {
+            li.removeClass('icme_listcc_hover').find('span.percentage').show();
+        } else if ( e.type === 'click' ) {
+            li.removeClass('icme_listcc_hover');
+            li.toggleClass('icme_listcc_selected');
+
+            if ( wasSelected ) { // before click
+                li.addClass('icme_listcc_hover');
+            }
+        }
+
+        return false; // ff 3.6 compatibility
+    });
+
+    this.activatedOnce = true;
 };
 
 ListCrossCheck.prototype.deactivate = function() {
@@ -935,7 +963,8 @@ ListCrossCheck.prototype.deactivate = function() {
     // if there's still selected top lists, change them back to normal
     $(selectedToplists).removeClass('icme_listcc_selected').find('span.percentage').show();
 
-    $('ol#itemListToplists').children('li').removeClass('icme_listcc_selected').removeClass('icme_listcc_hover');
+    $('ol#itemListToplists').children('li')
+        .removeClass('icme_listcc_selected').removeClass('icme_listcc_hover');
     $('button#icme_listcc_check, button#cfgListCCDeactivate').remove();
     $('li#topListCategoryCCSelected').remove();
     $('button#cfgListCCActivate').prop('disabled', false);
@@ -950,7 +979,9 @@ ListCrossCheck.prototype.check = function() {
     var toplistCont = $('ol#itemListToplists');
 
     // make selected top lists normal under the regular tabs
-    toplistCont.children('li.icme_listcc_selected').removeClass('icme_listcc_selected').find('span.percentage').show();
+    toplistCont.children('li.icme_listcc_selected')
+        .removeClass('icme_listcc_selected')
+        .find('span.percentage').show();
 
     // get selected top lists
     var $toplists = toplistCont.children('li.icme_listcc');
@@ -987,7 +1018,8 @@ ListCrossCheck.prototype.getUncheckedFilms = function(listElem) {
     var _t = this;
 
     $.get(url, function(response) {
-        $(listElem).removeClass('icme_listcc_selected icme_listcc_pending').find('span.percentage').show();
+        $(listElem).removeClass('icme_listcc_selected icme_listcc_pending')
+            .find('span.percentage').show();
 
         var filter = _t.config.checks ? '' : 'li.unchecked';
         // the site returns html with extra whitespace
@@ -1007,10 +1039,10 @@ ListCrossCheck.prototype.updateMovies = function(content) {
 
     this.sequenceNumber += 1;
 
-    // keeps track if at least one movie on the current top list is also found on all previous top lists
-    // if the script is currently checking for movies found on all top lists. it's a major optimization
-    // that halts the script if there's a top list with 0 matches especially early on and doesn't go on
-    // to check all the rest of the lists wasting time
+    // keeps track if at least one movie on the current top list is also found
+    //   on all previous top lists (if checking for movies found on all top lists).
+    // it's a major optimization that halts the script if there's a top list with 0 matches
+    //   especially early on and doesn't go on to check all the rest of the lists wasting time
     var globalToplistMatch = false;
 
     var showPerfectMatches = this.config.match_all;
@@ -1038,25 +1070,25 @@ ListCrossCheck.prototype.updateMovies = function(content) {
             }
         }
 
-        // if a movie wasn't found on previous top lists
-        if ( !found ) {
-            // add it to the main movies array only if the script is not checking for matches on all top lists
-            // OR if the script is checking for matches on all top lists, but this is just the first top list
-            if ( !showPerfectMatches || this.sequenceNumber === 1 ) {
-                var $item = $(content[i]);
-                $item.find('.rank').html('0');
+        // if a movie wasn't found on previous top lists,
+        // add it to the main movies array
+        //   only if the script is not checking for matches on all top lists
+        // OR if the script is checking for matches on all top lists,
+        //   but this is just the first top list
+        if ( !found && ( !showPerfectMatches || this.sequenceNumber === 1 ) ) {
+            var $item = $(content[i]);
+            $item.find('.rank').html('0');
 
-                var itemid = $item.attr('id');
+            var itemid = $item.attr('id');
 
-                // check if owned
-                var owned = evalOrParse(gmGetValue('owned_movies', '[]'));
-                if (owned.indexOf(itemid) !== -1) {
-                    $item.removeClass('notowned').addClass('owned');
-                }
-
-                // t = title, c = count, u = url, y = year
-                this.movies.push( {t: movie, c: 1, u: movieUrl, y: movieYear, jq: $item} );
+            // check if owned
+            var owned = evalOrParse(gmGetValue('owned_movies', '[]'));
+            if (owned.indexOf(itemid) !== -1) {
+                $item.removeClass('notowned').addClass('owned');
             }
+
+            // t = title, c = count, u = url, y = year
+            this.movies.push( {t: movie, c: 1, u: movieUrl, y: movieYear, jq: $item} );
         }
     }
 
@@ -1120,16 +1152,6 @@ ListCrossCheck.prototype.outputMovies = function() {
     });
 
     if ( this.movies.length > 0 ) {
-        /*var movie_table = '<div id="icme_listcc_container" class="container" style="position: relative; width: 830px; height: 240px; overflow: scroll; margin-bottom: 10px">'
-                        + '<table id="icme_listcc_movie_table"><tr><th style="width: 70px">Top lists</th><th>Movie title (total: ' + this.movies.length + ')</th></tr>';
-
-        for ( var i = 0; i < this.movies.length; i++ ) {
-            movie_table += '<tr><td style="float: right; padding-right: 20px">' + this.movies[i].c
-                        + '</td><td><a href="' + this.movies[i].u + '">' + this.movies[i].t + ', ' + this.movies[i].y + '</a></td></tr>'
-        }
-
-        movie_table += '</table></div><ol id="itemListMovies" class="itemList listViewNormal"></ol>';*/
-
         var menu = '<ul>';
         for (var i = 0; i < this.toplists.length; ++i) {
             menu += '<li><b>' + $(this.toplists[i]).find('h2').text() + '</b></li>';
@@ -1140,10 +1162,6 @@ ListCrossCheck.prototype.outputMovies = function() {
             '<a href="#" title="View all movies">All (' + this.movies.length + ')</a></li>' +
             '<li class="listFilterExportCSV">' +
             '<a href="#" title="Export all movies in CSV format">Export CSV</a></li>' +
-            /*'<li class="topListMoviesFilter " id="listFilterChecked">' +
-            '<a title="View all your checked movies" href="#" id="linkListFilterChecked">Checked <span id="topListMoviesCheckedCount"></span></a></li>' +
-            '<li class="topListMoviesFilter " id="listFilterUnchecked">' +
-            '<a title="View all your unchecked movies" href="#" id="linkListFilterUnchecked">Unchecked <span id="topListMoviesUncheckedCount"></span></a></li>' +*/
             '</ul>';
 
         // hide previous movie list
@@ -1209,7 +1227,9 @@ ListCrossCheck.prototype.createTab = function() {
         return;
     }
 
-    var tab = '<li id="listFilterCRSelected"><a href="#" class="icme_listcc">Cross-reference</a><strong style="display: none">Cross-reference</strong></li>';
+    var tab = '<li id="listFilterCRSelected">' +
+        '<a href="#" class="icme_listcc">Cross-reference</a>' +
+        '<strong style="display: none">Cross-reference</strong></li>';
 
     var $tlfilter = $('ul.tabMenu', 'div#itemContainer');
     $tlfilter.append( tab );
@@ -1231,13 +1251,14 @@ ListCrossCheck.prototype.createTab = function() {
 
             var $topLists = $topListUl.children('li.icme_listcc_selected').clone();
 
-            //$topListUl.children("li.icme_listcc_selected").removeClass("icme_listcc_selected");
-
-            $topLists.removeClass('imdb critics prizes website institute misc icme_listcc_selected').addClass('icme_listcc').find('span.percentage').show();
+            $topLists
+                .removeClass('imdb critics prizes website institute misc icme_listcc_selected')
+                .addClass('icme_listcc').find('span.percentage').show();
 
             $topListUl.append( $topLists );
 
-            if ( $('li.icme_listcc', 'ol#itemListToplists').length >= 2 && $('button#icme_listcc_check').length === 0 ) {
+            var selectedTwoOrMore = $('li.icme_listcc', 'ol#itemListToplists').length >= 2;
+            if ( selectedTwoOrMore && $('button#icme_listcc_check').length === 0 ) {
                 var btn = '<button id="icme_listcc_check">Cross-reference</button>';
 
                 $('div#crActions').append(btn);
@@ -1260,7 +1281,7 @@ ListCrossCheck.prototype.createTab = function() {
                         });
                     }
                 });
-            } else if ( $('li.icme_listcc', 'ol#itemListToplists').length < 2 && $('button#icme_listcc_check').length === 1 ) {
+            } else if ( !selectedTwoOrMore && $('button#icme_listcc_check').length === 1 ) {
                 $('button#icme_listcc_check').remove();
             }
         }
@@ -1312,10 +1333,16 @@ function HideTags(config) {
 
 HideTags.prototype.attach = function() {
     if (this.config.enabled) {
-        gmAddStyle('ol#itemListToplists li .info:last-child, ol#itemListMovies li .tagList { display: none !important; }');
+        gmAddStyle(
+            'ol#itemListToplists li .info:last-child, ' +
+            'ol#itemListMovies li .tagList ' +
+                '{ display: none !important; }');
 
         if (this.config.show_hover) {
-            gmAddStyle('ol#itemListToplists li:hover .info:last-child, ol#itemListMovies li:hover .tagList { display: block !important; }');
+            gmAddStyle(
+                'ol#itemListToplists li:hover .info:last-child, ' +
+                'ol#itemListMovies li:hover .tagList ' +
+                    '{ display: block !important; }');
         }
     }
 };
@@ -1370,7 +1397,8 @@ WatchlistTab.prototype.attach = function() {
 
     // move the order by and views to filter box
     if ($('#orderByAndView').length === 0) {
-        $('#topList').append('<div id="orderByAndView" style="z-index:200;position:absolute;top:30px;right:0;width:300px;height:20px"> </div>');
+        $('#topList').append('<div id="orderByAndView" ' +
+            'style="z-index:200; position:absolute; top:30px; right:0; width:300px; height:20px">');
         $('#listOrdering').detach().appendTo('#orderByAndView');
         $('#listViewswitch').detach().appendTo('#orderByAndView');
     }
@@ -1481,7 +1509,8 @@ Owned.prototype.attach = function() {
 
     // move the order by and views to filter box
     if (!$('#orderByAndView').length && $('#topList').length) {
-        $('#topList').append('<div id="orderByAndView" style="z-index:200;position:absolute;top:30px;right:0;width:300px;height:20px"> </div>');
+        $('#topList').append('<div id="orderByAndView" ' +
+            'style="z-index:200; position:absolute; top:30px; right:0; width:300px; height:20px">');
         $('#listOrdering').detach().appendTo('#orderByAndView');
         $('#listViewswitch').detach().appendTo('#orderByAndView');
     }
@@ -1534,29 +1563,32 @@ LargeList.prototype.attach = function() {
 
     if (this.config.autoload) {
         this.load();
-    } else {
-        // create link
-        var link = '<span style="float: right; margin-left: 15px"><a id="icme_large_posters" href="#">Large posters</a></span>';
-
-        if ( $('div#list_container').length !== 1 ) {
-            var container = '<div id="list_container" style="height: 35px; position: relative">' + link + '</div>';
-
-            $('#movies').parent().before( container );
-        } else {
-            if ($('#list_container').find('p').length === 1) {
-                $('#list_container p:first').append('<span> &mdash; </span>' + link);
-            } else {
-                $('div#list_container').append( link );
-            }
-        }
-
-        var _t = this;
-        $('#icme_large_posters').on('click', function(e) {
-            e.preventDefault();
-
-            _t.load();
-        });
+        return;
     }
+
+    // create link
+    var link = '<span style="float: right; margin-left: 15px">' +
+        '<a id="icme_large_posters" href="#">Large posters</a></span>';
+
+    if ( $('div#list_container').length !== 1 ) {
+        var container = '<div id="list_container" style="height: 35px; ' +
+            'position: relative">' + link + '</div>';
+
+        $('#movies').parent().before( container );
+    } else {
+        if ($('#list_container').find('p').length === 1) {
+            $('#list_container p:first').append('<span> &mdash; </span>' + link);
+        } else {
+            $('div#list_container').append( link );
+        }
+    }
+
+    var _t = this;
+    $('#icme_large_posters').on('click', function(e) {
+        e.preventDefault();
+
+        _t.load();
+    });
 };
 
 LargeList.prototype.load = function() {
@@ -1566,18 +1598,35 @@ LargeList.prototype.load = function() {
 
     this.loaded = true;
 
-    var style = '#itemListMovies > .listItem { float:left !important; height: 330px !important; width: 255px !important; }' +
-        '.listItem .listImage { float:none !important; width: 230px !important; height: 305px !important; left:-18px !important; top:-18px !important; margin:0!important }' +
-        '.listImage a {width:100% !important; height:100% !important; background: url("/images/dvdCover.png") no-repeat scroll center center transparent !important;}' +
-        '.listImage .coverImage { width:190px !important; height:258px !important; top:21px !important; left: 19px !important; right:auto !important; }' +
-        '.listItem .rank { top: 15px !important; position:absolute !important; height:auto !important; width:65px !important; right:0 !important; margin:0 !important; font-size:30px !important }' +
-        '.listItem .rank .positiondifference span { font-size: 12px !important }' +
-        '.listItem h2 { z-index:11 !important; font-size:14px !important; width:100% !important; margin:-30px 0 0 0 !important; }' +
-        '.listItem .info { font-size:12px !important; width:100% !important; height:auto !important; line-height:16px !important; margin-top:4px !important }' +
-        '.checkbox { top:85px !important; right:12px !important }' +
-        '#itemListMovies .optionIconMenu { top:120px !important; right:20px !important }' +
-        '#itemListMovies .optionIconMenu li { display: block !important }' +
-        '#itemListMovies .optionIconMenuCheckbox { right:20px !important }';
+    var style =
+        '#itemListMovies > .listItem ' +
+            '{ float:left; height: 330px; width: 255px; } ' +
+        '.listItem .listImage ' +
+            '{ float:none; width: 230px; height: 305px; left:-18px; top:-18px; margin:0; } ' +
+        '.listImage a ' +
+            '{ width:100%; height:100%; background: url("/images/dvdCover.png") ' +
+            'no-repeat scroll center center transparent; } ' +
+        '.listImage .coverImage ' +
+            '{ width:190px; height:258px; top:21px; left: 19px; right:auto; } ' +
+        '.listItem .rank ' +
+            '{ top: 15px; position:absolute; height:auto; width:65px; ' +
+            'right:0; margin:0; font-size:30px; } ' +
+        '.listItem .rank .positiondifference span ' +
+            '{ font-size: 12px; } ' +
+        '.listItem h2 ' +
+            '{ z-index:11; font-size:14px; width:100%; margin:-30px 0 0 0; } ' +
+        '.listItem .info ' +
+            '{ font-size:12px; width:100%; height:auto; line-height:16px; margin-top:4px; } ' +
+        '.checkbox ' +
+            '{ top:85px; right:12px; } ' +
+        '#itemListMovies .optionIconMenu ' +
+            '{ top:120px; right:20px; } ' +
+        '#itemListMovies .optionIconMenu li ' +
+            '{ display: block; } ' +
+        '#itemListMovies .optionIconMenuCheckbox ' +
+            '{ right:20px; }';
+
+    style = style.replace(/;/g, ' !important;');
 
     gmAddStyle(style);
 
@@ -1590,7 +1639,9 @@ LargeList.prototype.load = function() {
             cururl = cururl.slice(4, -1).replace('small', 'medium').replace('Small', 'Medium');
         }
         var img = document.createElement('img');
-        img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAMSURBVBhXY5j8rA8ABBcCCCnPKCcAAAAASUVORK5CYII=';
+        img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIA' +
+            'AACQd1PeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMA' +
+            'AA7DAcdvqGQAAAAMSURBVBhXY5j8rA8ABBcCCCnPKCcAAAAASUVORK5CYII=';
         img.className = 'coverImage';
         img.setAttribute('data-original', cururl);
         $c[i].parentNode.appendChild(img);
@@ -1861,13 +1912,15 @@ ListsTabDisplay.prototype.getLists = function(listIDs) {
 
 ListsTabDisplay.prototype.settings = {
     title: 'Lists tab display',
-    desc: 'Organize movie info tab with all lists (\/movies\/*\/rankings\/, <a href="/movies/pulp+fiction/rankings/">example</a>)',
+    desc: 'Organize movie info tab with all lists (/movies/*/rankings/, ' +
+          '<a href="/movies/pulp+fiction/rankings/">example</a>)',
     index: 'lists_tab_display',
-    includes: ['icheckmovies.com/lists/(.+)',
-               'icheckmovies.com/search/movies/(.+)',
-               'icheckmovies.com/movies/.+/rankings/(.*)',
-               'icheckmovies.com/movies/[^/]*$', // list of all movies
-               'icheckmovies.com/movies/((un)?checked|favorited|disliked|owned|watchlist|recommended)/'],
+    includes: [
+        'icheckmovies.com/lists/(.+)',
+        'icheckmovies.com/search/movies/(.+)',
+        'icheckmovies.com/movies/.+/rankings/(.*)',
+        'icheckmovies.com/movies/[^/]*$', // list of all movies
+        'icheckmovies.com/movies/((un)?checked|favorited|disliked|owned|watchlist|recommended)/'],
     excludes: [],
     options: [{
         name: 'redirect',
@@ -1963,7 +2016,8 @@ ExportLists.prototype.attach = function() {
 
 ExportLists.prototype.settings = {
     title: 'Export lists',
-    desc: 'Download any list as .csv (doesn\'t support search results). Emulates the paid feature, so don\'t enable it if you have a paid account',
+    desc: 'Download any list as .csv (doesn\'t support search results). ' +
+          'Emulates the paid feature, so don\'t enable it if you have a paid account',
     index: 'export_lists',
     includes: ['icheckmovies.com/lists/(.+)'],
     excludes: [],

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -233,7 +233,7 @@ ICM_ConfigWindow.prototype.initColorPickers = function() {
     $(".colorpickertext").on("change input paste", function() {
         $(this).next().spectrum("set", $(this).val());
     });
-}
+};
 
 ICM_ConfigWindow.prototype.build = function() {
     // Sort module list by title

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -51,6 +51,7 @@ function setProperty(path, obj, val) {
 // ff+gm: uneval for obj: ({a:5})
 // gc+tm: uneval for obj: $1 = {"a":5};
 function evalOrParse(str) {
+    /* jshint evil: true */
     try {
         return JSON.parse(str);
     } catch (e) {

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -21,10 +21,11 @@
 //+ Jonas Raoni Soares Silva
 //@ http://jsfromhell.com/array/shuffle [rev. #1]
 var shuffle = function(v) {
-    /* jshint nocomma: false */
+    /* jshint nocomma: false, noempty: false */
     for (var j, x, i = v.length;
         i > 1;
-        j = Math.floor(Math.random() * i), x = v[--i], v[i] = v[j], v[j] = x);
+        j = Math.floor(Math.random() * i), x = v[--i], v[i] = v[j], v[j] = x) {
+    }
     return v;
 };
 
@@ -118,8 +119,9 @@ function ICM_Config() {
 // Initialize stuff
 ICM_Config.prototype.Init = function() {
     var oldcfg = evalOrParse(GM_getValue("icm_enhanced_cfg"));
-    if (!oldcfg)
+    if (!oldcfg) {
         return;
+    }
 
     var o = oldcfg.script_config,
         n = this.cfg.script_config,
@@ -237,7 +239,7 @@ ICM_ConfigWindow.prototype.initColorPickers = function() {
 
 ICM_ConfigWindow.prototype.build = function() {
     // Sort module list by title
-    this.modules.sort(function(a,b) { return a.title > b.title ? 1 : -1; });
+    this.modules.sort(function(a, b) { return a.title > b.title ? 1 : -1; });
 
     // Create and append a new item in the drop down menu under your username
     var cfgLink = '<li><a id="icm_enhanced_cfg" href="#" title="Configure iCheckMovies Enhanced script options">ICM Enhanced</a></li>';
@@ -284,7 +286,7 @@ ICM_ConfigWindow.prototype.build = function() {
 
     $("div#cfgModal").on( "change", "input, textarea", function() {
         var index = $(this).data("cfg-index");
-        if(index === undefined) {
+        if (index === undefined) {
             return;
         }
 
@@ -414,8 +416,9 @@ ICM_UpcomingAwardsList.prototype.Attach = function() {
         var abs = this.config.show_absolute;
         var get_span = function(award, cutoff) {
             var num = Math.ceil(total_items * cutoff) - checks;
-            if (!abs && num <= 0)
+            if (!abs && num <= 0) {
                 return '';
+            }
             return '<span style="margin-left: 30px">' + award + ': <b>' + num + '</b></span>';
         };
 
@@ -507,8 +510,9 @@ ICM_UpcomingAwardsOverview.prototype.PopulateLists = function() {
         var $el = $(this),
             count_arr = $el.find(curSel.rank).text().match(/\d+/g);
 
-        if (!count_arr)
+        if (!count_arr) {
             return;
+        }
 
         var checks      = parseInt( count_arr[0], 10 ),
             total_items = parseInt( count_arr[1], 10 ),
@@ -518,8 +522,9 @@ ICM_UpcomingAwardsOverview.prototype.PopulateLists = function() {
 
         award_types.forEach(function(award) {
             var award_checks = Math.ceil(total_items * award[1]) - checks;
-            if (award_checks <= 0)
+            if (award_checks <= 0) {
                 return false; // exit loop; the order of array is important!
+            }
 
             that.lists.push({
                 'award_checks': award_checks,
@@ -533,21 +538,22 @@ ICM_UpcomingAwardsOverview.prototype.PopulateLists = function() {
 
 ICM_UpcomingAwardsOverview.prototype.SortLists = function() {
     // sort lists array by least required checks ASC,
-	// then by awards where checks are equal ASC, then by list title ASC
+    // then by awards where checks are equal ASC, then by list title ASC
     var award_order = { "Bronze": 0, "Silver": 1, "Gold": 2, "Platinum": 3 };
     this.lists.sort(function(a, b) {
-        if (a.award_checks < b.award_checks)
+        if (a.award_checks < b.award_checks) {
             return -1;
-        if (a.award_checks > b.award_checks)
+        } else if (a.award_checks > b.award_checks) {
             return 1;
-        if (award_order[a.award_type] < award_order[b.award_type])
+        } else if (award_order[a.award_type] < award_order[b.award_type]) {
             return -1;
-        if (award_order[a.award_type] > award_order[b.award_type])
+        } else if (award_order[a.award_type] > award_order[b.award_type]) {
             return 1;
-        if (a.list_title < b.list_title)
+        } else if (a.list_title < b.list_title) {
             return -1;
-        if (a.list_title > b.list_title)
+        } else if (a.list_title > b.list_title) {
             return 1;
+        }
         return 0;
     });
 };
@@ -713,8 +719,9 @@ ICM_ListCustomColors.prototype.Attach = function() {
         var list_colors_css = "";
 
         var buildCSS = function(className, color) {
-            if (!color.length)
+            if (!color.length) {
                 return;
+            }
             var sel = 'ol#itemListMovies li.' + className;
             list_colors_css += sel + ', ' + sel + ' ul.optionIconMenu { background-color: ' + color + ' !important; }';
         };
@@ -893,7 +900,7 @@ ICM_ListCrossCheck.prototype.Check = function() {
         var checks = $(x).find("span.info > strong:first").text().split("/");
         return checks[1] - checks[0];
     };
-    jq_toplists.sort(function(a,b) {
+    jq_toplists.sort(function(a, b) {
         return get_unchecked(a) < get_unchecked(b) ? -1 : 1;
     });
 
@@ -1032,13 +1039,20 @@ ICM_ListCrossCheck.prototype.OutputMovies = function() {
     }
 
     // Sort by checks DESC, then by year ASC, then by title ASC
-    this.movies.sort(function(a,b) {
-        if (a.c > b.c) return -1;
-        if (a.c < b.c) return 1;
-        if (a.y < b.y) return -1;
-        if (a.y > b.y) return 1;
-        if (a.t < b.t) return -1;
-        if (a.t > b.t) return 1;
+    this.movies.sort(function(a, b) {
+        if (a.c > b.c) {
+            return -1;
+        } else if (a.c < b.c) {
+            return 1;
+        } else if (a.y < b.y) {
+            return -1;
+        } else if (a.y > b.y) {
+            return 1;
+        } else if (a.t < b.t) {
+            return -1;
+        } else if (a.t > b.t) {
+            return 1;
+        }
         return 0;
     });
 
@@ -1498,21 +1512,19 @@ ICM_LargeList.prototype.load = function() {
         ".listItem h2 { z-index:11 !important; font-size:14px !important; width:100% !important; margin:-30px 0 0 0 !important; }" +
         ".listItem .info { font-size:12px !important; width:100% !important; height:auto !important; line-height:16px !important; margin-top:4px !important }" +
         ".checkbox { top:85px !important; right:12px !important }" +
-        //".checkbox { display:none !important }" +
         "#itemListMovies .optionIconMenu { top:120px !important; right:20px !important }" +
         "#itemListMovies .optionIconMenu li { display: block !important }" +
         "#itemListMovies .optionIconMenuCheckbox { right:20px !important }";
-        //".optionIconMenu { display:none !important }";
 
     GM_addStyle(style);
 
     var $c = $("#itemListMovies").find("div.coverImage").hide();
     for (var i = 0; i < $c.length; i++) {
         var cururl = $c[i].style.backgroundImage;
-        if (cururl.substr(4,1) !== "h") {
-            cururl = cururl.slice(5,-2).replace("small", "medium").replace("Small", "Medium");
+        if (cururl.substr(4, 1) !== "h") {
+            cururl = cururl.slice(5, -2).replace("small", "medium").replace("Small", "Medium");
         } else { // chrome handles urls differently
-            cururl = cururl.slice(4,-1).replace("small", "medium").replace("Small", "Medium");
+            cururl = cururl.slice(4, -1).replace("small", "medium").replace("Small", "Medium");
         }
         var img = document.createElement("img");
         img.src = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAMSURBVBhXY5j8rA8ABBcCCCnPKCcAAAAASUVORK5CYII=";
@@ -1640,22 +1652,22 @@ ICM_ListOverviewSort.prototype.Straighten = function(list) {
 ICM_ListOverviewSort.prototype.Interweave = function(list) {
     var res = [],
         half_len = Math.ceil(list.length / 2);
-    for (var i = 0; i< half_len; i++) {
+    for (var i = 0; i < half_len; i++) {
         res.push(list[i]);
-        if (i+half_len < list.length) {
-            res.push(list[i+half_len]);
+        if (i + half_len < list.length) {
+            res.push(list[i + half_len]);
         }
     }
     return res;
 };
 
 // tests
-// a = [1, 'a', 2, 'b', 3, 'c', 4, 'd'];
-// b = [1, 'a', 2, 'b', 3, 'c', 4];
-// function test(arr) {
-    // return JSON.stringify(arr) === JSON.stringify(interweave(straighten(arr)));
-// }
-// test(a) && test(b)
+/* a = [1, 'a', 2, 'b', 3, 'c', 4, 'd'];
+b = [1, 'a', 2, 'b', 3, 'c', 4];
+function test(arr) {
+    return JSON.stringify(arr) === JSON.stringify(interweave(straighten(arr)));
+}
+test(a) && test(b) */
 
 ICM_ListOverviewSort.prototype.settings = {
     title: "Progress page",
@@ -1939,8 +1951,9 @@ ICM_ProgressTopX.prototype.addStats = function(event) {
             oldText = list.text(),
             curRank = oldText.match(/\d+/);
 
-        if (curRank < targetPage * 25)
-           return;
+        if (curRank < targetPage * 25) {
+            return;
+        }
 
         var url = list.attr("href").replace(/=.*$/, "=" + targetPage),
             progress = parseInt(list.parent().text().match(/\d+/), 10);

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -614,7 +614,8 @@ UpcomingAwardsOverview.prototype.getIconFactory = function() {
         'gHT5me0AAAAASUVORK5CYII=';
 
     /**
-     * Generate <img> for a hide/unhide button
+     * Generate <img> for a hide/unhide button.
+     *
      * @param {boolean} hide - true to hide, false to unhide
      * @param {string} listTitle
      */
@@ -1014,9 +1015,9 @@ ListCrossCheck.prototype.check = function() {
 };
 
 /**
- * Get unchecked films from a top list
+ * Get unchecked films from a top list.
  *
- * @param listElem jQuery object of the top list element
+ * @param {jQuery} listElem - the top list element
  */
 ListCrossCheck.prototype.getUncheckedFilms = function(listElem) {
     var url = $(listElem).find('a').attr('href');
@@ -1038,9 +1039,9 @@ ListCrossCheck.prototype.getUncheckedFilms = function(listElem) {
 };
 
 /**
- * Update array of movies
+ * Update array of movies.
  *
- * @param content jQuery object that consists of unchecked movies (<li> elements) on a top list page
+ * @param {jQuery} content - unchecked movies (<li> elements) on a top list page
  */
 ListCrossCheck.prototype.updateMovies = function(content) {
     var movieTitles = content.find('h2');
@@ -1758,7 +1759,8 @@ ListOverviewSort.prototype.rearrange = function(order, section) {
 // [1, 'a', 2, 'b', 3, 'c']    -> [1, 2, 3, 'a', 'b', 'c']
 // [1, 'a', 2, 'b', 3, 'c', 4] -> [1, 2, 3, 4, 'a', 'b', 'c']
 ListOverviewSort.prototype.straighten = function(list) {
-    var even = [], odd = [];
+    var even = [],
+        odd  = [];
     for (var i = 0; i < list.length; i++) {
         if (i % 2 === 0) {
             even.push(list[i]);

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -25,15 +25,17 @@ var gmSetValue = GM_setValue,
     gmGetResourceText = GM_getResourceText;
 // jscs:enable requireCamelCaseOrUpperCaseIdentifiers
 
-//+ Jonas Raoni Soares Silva
-//@ http://jsfromhell.com/array/shuffle [rev. #1]
+// + Jonas Raoni Soares Silva
+// @ http://jsfromhell.com/array/shuffle [rev. #1]
 var shuffle = function(v) {
     /* jshint nocomma: false, noempty: false */
+    // jscs:disable disallowEmptyBlocks
     for (var j, x, i = v.length;
         i > 1;
         j = Math.floor(Math.random() * i), x = v[--i], v[i] = v[j], v[j] = x) {
     }
     return v;
+    // jscs:enable disallowEmptyBlocks
 };
 
 // Get object property by a dot-separated path
@@ -246,7 +248,9 @@ ConfigWindow.prototype.initColorPickers = function() {
 
 ConfigWindow.prototype.build = function() {
     // Sort module list by title
-    this.modules.sort(function(a, b) { return a.title > b.title ? 1 : -1; });
+    this.modules.sort(function(a, b) {
+        return a.title > b.title ? 1 : -1;
+    });
 
     // Create and append a new item in the drop down menu under your username
     var cfgLink = '<li><a id="icm_enhanced_cfg" href="#"' +
@@ -396,7 +400,7 @@ RandomFilmLink.prototype.pickRandomFilm = function() {
     }
 
     $('ol#itemListMovies > li').hide();
-    $($unchecked[ randNum ]).show();
+    $($unchecked[randNum]).show();
 };
 
 RandomFilmLink.prototype.settings = {
@@ -523,8 +527,8 @@ UpcomingAwardsOverview.prototype.loadAwardData = function() {
 UpcomingAwardsOverview.prototype.populateLists = function() {
     var that = this,
         $allLists = $('ol#progressall, ol#itemListToplists').children('li'),
-        sel = {progress: {rank: 'span.rank', title: 'h3 > a'},
-               lists: {rank: 'span.info > strong:first', title: 'h2 > a.title'}},
+        sel = { progress: { rank: 'span.rank', title: 'h3 > a' },
+               lists: { rank: 'span.info > strong:first', title: 'h2 > a.title' } },
         // use different selectors depending on page
         curSel = location.href.indexOf('progress') !== -1 ?
                  sel.progress : sel.lists,
@@ -551,10 +555,10 @@ UpcomingAwardsOverview.prototype.populateLists = function() {
             }
 
             that.lists.push({
-                'awardChecks': awardChecks,
-                'awardType':   award[0],
-                'listTitle':   listTitle,
-                'listUrl':     listUrl
+                awardChecks: awardChecks,
+                awardType:   award[0],
+                listTitle:   listTitle,
+                listUrl:     listUrl
             });
         });
     });
@@ -563,7 +567,7 @@ UpcomingAwardsOverview.prototype.populateLists = function() {
 UpcomingAwardsOverview.prototype.sortLists = function() {
     // sort lists array by least required checks ASC,
     // then by awards where checks are equal ASC, then by list title ASC
-    var awardOrder = { 'Bronze': 0, 'Silver': 1, 'Gold': 2, 'Platinum': 3 };
+    var awardOrder = { Bronze: 0, Silver: 1, Gold: 2, Platinum: 3 };
     this.lists.sort(function(a, b) {
         if (a.awardChecks < b.awardChecks) {
             return -1;
@@ -1092,7 +1096,7 @@ ListCrossCheck.prototype.updateMovies = function(content) {
             }
 
             // t = title, c = count, u = url, y = year
-            this.movies.push({t: movie, c: 1, u: movieUrl, y: movieYear, jq: $item});
+            this.movies.push({ t: movie, c: 1, u: movieUrl, y: movieYear, jq: $item });
         }
     }
 
@@ -1241,10 +1245,10 @@ ListCrossCheck.prototype.createTab = function() {
     var _t = this;
 
     // Modified from ICM source. Make the tab work.
-    $('#listFilterCRSelected a').on('click', function () {
+    $('#listFilterCRSelected a').on('click', function() {
         var a = $(this).attr('class'),
             b = $(this).closest('li');
-        $('.tabMenu').find('li').each(function () {
+        $('.tabMenu').find('li').each(function() {
             $(this).removeClass('active');
         });
         b.addClass('active');
@@ -1723,7 +1727,7 @@ ListOverviewSort.prototype.rearrange = function(order, section) {
     if (this.config.autosort) {
         var lookupMap = toplistArr.map(function(item, i) {
             var width = $(item).find('span.progress').css('width').replace('px', '');
-            return {index: i, value: parseFloat(width)};
+            return { index: i, value: parseFloat(width) };
         });
 
         lookupMap.sort(function(a, b) {
@@ -1884,7 +1888,7 @@ ListsTabDisplay.prototype.attach = function() {
     } else if (_c.redirect) { // = if on a list page
         var linksToLists = $('.listItemMovie > .info > a:last-of-type');
 
-        linksToLists.each(function () {
+        linksToLists.each(function() {
             var link = $(this),
                 url = link.attr('href').replace('?tags=user:icheckmovies', '');
             link.attr('href', url);
@@ -2054,10 +2058,10 @@ function ProgressTopX(config) {
 ProgressTopX.prototype.attach = function() {
     if (this.config.enabled) {
         var css = 'float: left; margin-right: 0.5em',
-            attr = {text: 'Load stats', id: 'icme_req_for_top', href: '#', style: css},
+            attr = { text: 'Load stats', id: 'icme_req_for_top', href: '#', style: css },
             // can't pass the value directly in case of user changing it and not reloading
-            loadLink = $('<a>', attr).click({cfg: this.config}, this.addStats),
-            spanElem = $('<span>', {text: ' | ', style: css});
+            loadLink = $('<a>', attr).click({ cfg: this.config }, this.addStats),
+            spanElem = $('<span>', { text: ' | ', style: css });
 
         $('#listOrderingWrapper').prepend(loadLink, spanElem);
     }

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -342,29 +342,31 @@ function RandomFilmLink(config) {
 
 // Creates an element and inserts it into the DOM
 RandomFilmLink.prototype.attach = function() {
-    if ( this.config.enabled ) {
-        var randomFilm =
-            '<span style="float:right; margin-left: 15px">' +
-                '<a href="#" id="randomFilm">Help me pick a film!</a></span>';
-
-        if ( $('div#list_container').length !== 1 ) {
-            var container =
-                '<div id="list_container" style="height: 35px; position: relative">' +
-                    randomFilm + '</div>';
-
-            $('#movies').parent().before( container );
-        } else {
-            $('div#list_container').append( randomFilm );
-        }
-
-        var that = this;
-
-        $('div#list_container').on( 'click', 'a#randomFilm', function(e) {
-            e.preventDefault();
-
-            that.pickRandomFilm();
-        });
+    if ( !this.config.enabled ) {
+        return;
     }
+
+    var randomFilm =
+        '<span style="float:right; margin-left: 15px">' +
+            '<a href="#" id="randomFilm">Help me pick a film!</a></span>';
+
+    if ( $('div#list_container').length !== 1 ) {
+        var container =
+            '<div id="list_container" style="height: 35px; position: relative">' +
+                randomFilm + '</div>';
+
+        $('#movies').parent().before( container );
+    } else {
+        $('div#list_container').append( randomFilm );
+    }
+
+    var that = this;
+
+    $('div#list_container').on( 'click', 'a#randomFilm', function(e) {
+        e.preventDefault();
+
+        that.pickRandomFilm();
+    });
 };
 
 // Displays a random film on a list
@@ -372,28 +374,29 @@ RandomFilmLink.prototype.pickRandomFilm = function() {
     var $unchecked = $('ol#itemListMovies > li.unchecked'),
         randNum;
 
-    if ( $unchecked.length > 0 ) {
-        if ( this.config.unique ) {
-            // Generate random numbers
-            if ( this.randomNums.length === 0 ) {
-                // Populate randomNums
-                for ( var i = 0; i < $unchecked.length; i++ ) {
-                    this.randomNums.push( i );
-                }
+    if ( !$unchecked.length ) {
+        return;
+    }
 
-                // Shuffle the results for randomness in-place
-                shuffle( this.randomNums );
+    if ( this.config.unique ) {
+        // Generate random numbers
+        if ( !this.randomNums.length ) {
+            // Populate randomNums
+            for ( var i = 0; i < $unchecked.length; i++ ) {
+                this.randomNums.push( i );
             }
 
-            randNum = this.randomNums.pop();
-        } else {
-            randNum = Math.floor( Math.random() * $unchecked.length );
+            // Shuffle the results for randomness in-place
+            shuffle( this.randomNums );
         }
 
-        $('ol#itemListMovies > li').hide();
-
-        $( $unchecked[ randNum ] ).show();
+        randNum = this.randomNums.pop();
+    } else {
+        randNum = Math.floor( Math.random() * $unchecked.length );
     }
+
+    $('ol#itemListMovies > li').hide();
+    $( $unchecked[ randNum ] ).show();
 };
 
 RandomFilmLink.prototype.settings = {
@@ -425,33 +428,34 @@ function UpcomingAwardsList(config) {
 }
 
 UpcomingAwardsList.prototype.attach = function() {
-    if ( this.config.enabled && $('#itemListMovies').length ) {
-        var totalItems = parseInt($('li#listFilterMovies').text().match(/\d+/));
-        var checks      = parseInt($('#topListMoviesCheckedCount').text().match(/\d+/));
+    if ( !this.config.enabled || !$('#itemListMovies').length ) {
+        return;
+    }
 
-        var statistics = '<span><b>Upcoming awards:</b>';
+    var totalItems = parseInt($('li#listFilterMovies').text().match(/\d+/)),
+        checks     = parseInt($('#topListMoviesCheckedCount').text().match(/\d+/)),
+        statistics = '<span><b>Upcoming awards:</b>',
+        abs = this.config.show_absolute;
 
-        var abs = this.config.show_absolute;
-        var getSpan = function(award, cutoff) {
-            var num = Math.ceil(totalItems * cutoff) - checks;
-            if (!abs && num <= 0) {
-                return '';
-            }
-            return '<span style="margin-left: 30px">' + award + ': <b>' + num + '</b></span>';
-        };
-
-        statistics += getSpan('Bronze', 0.5) + getSpan('Silver', 0.75) +
-                      getSpan('Gold', 0.9) + getSpan('Platinum', 1);
-
-        if ( $('div#list_container').length !== 1 ) {
-            var container =
-                '<div id="list_container" style="height: 35px; position: relative">' +
-                    statistics + '</div>';
-
-            $('#movies').parent().before( container );
-        } else {
-            $('div#list_container').append( statistics );
+    var getSpan = function(award, cutoff) {
+        var num = Math.ceil(totalItems * cutoff) - checks;
+        if (!abs && num <= 0) {
+            return '';
         }
+        return '<span style="margin-left: 30px">' + award + ': <b>' + num + '</b></span>';
+    };
+
+    statistics += getSpan('Bronze', 0.5) + getSpan('Silver', 0.75) +
+                  getSpan('Gold', 0.9) + getSpan('Platinum', 1);
+
+    if ( $('div#list_container').length !== 1 ) {
+        var container =
+            '<div id="list_container" style="height: 35px; position: relative">' +
+                statistics + '</div>';
+
+        $('#movies').parent().before( container );
+    } else {
+        $('div#list_container').append( statistics );
     }
 };
 
@@ -1073,8 +1077,8 @@ ListCrossCheck.prototype.updateMovies = function(content) {
         // if a movie wasn't found on previous top lists,
         // add it to the main movies array
         //   only if the script is not checking for matches on all top lists
-        // OR if the script is checking for matches on all top lists,
-        //   but this is just the first top list
+        //     OR if the script is     checking for matches on all top lists,
+        //        but this is just the first top list
         if ( !found && ( !showPerfectMatches || this.sequenceNumber === 1 ) ) {
             var $item = $(content[i]);
             $item.find('.rank').html('0');


### PR DESCRIPTION
Hi!

This PR adds support for checking the script with two Node.js tools: 
* [JSHint](http://jshint.com/about/) (`npm install jshint -g`) for ensuring code correctness (e.g. == vs ===, polluting global scope, unused/undeclared vars, for..in loops with properties bubbling up the hierarchy)
* [JSCS](http://jscs.info/overview.html) (`npm install jscs -g`) for maintaining consistent code style throughout the whole script (e.g. single quotes, camelCase, 100 chars per line, no spaces inside parens and brackets, $-prefix for jQuery vars).

I added rather strict configurations for both (.jshintrc, .jscsrc) that summarize many recommendations from popular js style guides, with some settings that are too strict commented out, and fixed all reported errors (most of them, at least; I had to disable some rules inline in 4 places, but that has a benefit of explicitly documenting intent to break those conventions). This covers all available options in jshint v.2.8.0 and jscs v.2.1.0, feel free to comment if you disagree with any of choices I've made. Both tools can be run with `<tool> icm-enhanced.user.js`.

Also included are some small bugfixes, last three can also be posted as a changelog for users:
cc2ed818e87e12051adf1e781f72fcc55b927cf7 - update jqModal to cdnjs-hosted v.1.3.0
51a454934c9251f35ab8cfb2816ba475d89cda67 - a single point to update version number
1e03d402857bec1fe0849bafaee1c09b2a7b24f1 - ListsTabDisplay: lists by deleted users no longer show up as official (ICM bug, [example](https://www.icheckmovies.com/movies/they+shoot+horses+dont+theyquestion/rankings/?tags=user:icheckmovies))
412dd4ff8932daaabe0217fe7172c7cb9e328787 - ListCrossCheck: FF 39.0.3 broke exporting cross-ref lists (temp fix)
644f8bc38439f79bf70acf9ee867c9eee073fb4a - ExportLists: properly encode fields with quotes 