### PR TITLE
More accurate page matching & small fixes

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -14,9 +14,10 @@
     // "validateNewlineAfterArrayElements": null,
 
     // --- Settings to revisit later
-    // "disallowParenthesesAroundArrowParam": null,
-    // "requireShorthandArrowFunctions": null,
-    // "requireTemplateStrings": null,
+    // "disallowKeywords": ["with"],
+    // "disallowParenthesesAroundArrowParam": true,
+    // "requireShorthandArrowFunctions": true,
+    // "requireTemplateStrings": { "allExcept": ["stringConcatenation"] },
     // "requireTrailingComma": null,
 
     "esnext": true,

--- a/.jscsrc
+++ b/.jscsrc
@@ -114,6 +114,7 @@
     "disallowSpacesInsideBrackets": true,
     "requireSpacesInsideObjectBrackets": "all",
     "disallowSpacesInsideParentheses": true,
+    "disallowSpacesInsideParenthesizedExpression": true,
     "disallowTrailingWhitespace": true,
     "disallowYodaConditions": true,
 

--- a/.jshintrc
+++ b/.jshintrc
@@ -17,7 +17,7 @@
 
     // Enforcing - deprecated (should be removed after v3.*)
     "camelcase"   : false, // Identifiers must be in camelCase
-                           // TODO: temporary disabled until fixed
+                           // NOTE: disabled, jscs allows to ignore properties
     "immed"       : true,  // Require immediate invocations to be wrapped in parens
     "newcap"      : false, // Require capitalization of all constructor functions
                            // NOTE: for GM_ APIs (their names break this convention)

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -16,6 +16,7 @@
 // @grant          GM_getValue
 // @grant          GM_addStyle
 // @grant          GM_getResourceText
+// @grant          unsafeWindow
 // ==/UserScript==
 
 // ----- Utils -----

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -211,7 +211,8 @@ ConfigWindow.prototype.loadOptions = function(idx) {
             indexAttr = ' data-cfg-index="' + index + '"';
 
         if (opt.type === 'checkbox') {
-            str += '<p><input type="checkbox"' + indexAttr +
+            str += '<p' + (opt.inline ? ' class="inline-opt"' : '') + '>' +
+                   (opt.frontDesc || '') + '<input type="checkbox"' + indexAttr +
                    (optValue ? ' checked="checked"' : '') + ' title="default: ' +
                    (opt.default ? 'yes' : 'no') + '">' + opt.desc + '</p>';
         } else if (opt.type === 'textinput') {
@@ -284,6 +285,7 @@ ConfigWindow.prototype.build = function() {
         'input[type=text] { font-family: monospace }' +
         '#module_settings { margin:10px 0; }' +
         '#module_settings > p { margin-bottom: 0.5em; }' +
+        '#module_settings > p.inline-opt { display: inline-block; margin-right: 5px }' +
         '#configSave { position: absolute; bottom:15px; left: 30px }' +
         'hr { border:0; height:1px; width:100%; background-color:#aaa; }';
 
@@ -1862,6 +1864,10 @@ function ListsTabDisplay(config) {
 }
 
 ListsTabDisplay.prototype.attach = function() {
+    if (!this.config.enabled) {
+        return;
+    }
+
     var isOnMoviePage = (new RegExp(this.settings.includes[2])).test(window.location.href),
         _c = this.config;
 
@@ -1952,24 +1958,33 @@ ListsTabDisplay.prototype.settings = {
         'icheckmovies.com/movies/((un)?checked|favorited|disliked|owned|watchlist|recommended)/'],
     excludes: [],
     options: [{
+        name: 'enabled',
+        desc: 'Enabled',
+        type: 'checkbox',
+        default: true
+    }, {
         name: 'redirect',
         desc: 'Redirect "in # lists" movie links to "All" lists tab',
         type: 'checkbox',
         default: true
     }, {
         name: 'sort_official',
-        desc: 'Auto-sort official lists',
+        frontDesc: 'Auto-sort (move to the top): ',
+        desc: 'official lists',
         type: 'checkbox',
+        inline: true,
         default: true
     }, {
         name: 'sort_filmos',
-        desc: 'Auto-sort filmographies',
+        desc: 'filmographies',
         type: 'checkbox',
+        inline: true,
         default: true
     }, {
         name: 'sort_groups',
-        desc: 'Auto-sort lists from user defined groups',
+        desc: 'lists from user defined groups',
         type: 'checkbox',
+        inline: true,
         default: true
     }, {
         name: 'group1',

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -18,6 +18,8 @@
 // @grant          GM_getResourceText
 // ==/UserScript==
 
+// ----- Utils -----
+
 // jscs:disable requireCamelCaseOrUpperCaseIdentifiers
 var gmInfo = GM_info,
     gmSetValue = GM_setValue,
@@ -73,6 +75,22 @@ function evalOrParse(str) {
     } catch (e) {
         console.log('Converting from old storage mode with spooky eval');
         return eval(str);
+    }
+}
+
+// ----- Interacting with ICM -----
+
+function addToMovieListBar(htmlStr) {
+    var $container = $('#icme_list_container');
+    if (!$container.length) {
+        $container = $('<div id="icme_list_container" style="height: 35px; ' +
+            'position: relative">' + htmlStr + '</div>');
+
+        $('#topList, #listTitle') // movieList and movieListGeneral+Special use different headers
+            .nextAll('.container').last()
+            .before($container);
+    } else {
+        $container.append(htmlStr);
     }
 }
 
@@ -366,20 +384,12 @@ RandomFilmLink.prototype.attach = function() {
 
     var randomFilm =
         '<span style="float:right; margin-left: 15px">' +
-            '<a href="#" id="randomFilm">Help me pick a film!</a></span>';
+            '<a href="#" id="icme_random_film">Help me pick a film!</a></span>';
 
-    if ($('div#list_container').length !== 1) {
-        var container =
-            '<div id="list_container" style="height: 35px; position: relative">' +
-                randomFilm + '</div>';
-
-        $('#movies').parent().before(container);
-    } else {
-        $('div#list_container').append(randomFilm);
-    }
+    addToMovieListBar(randomFilm);
 
     var that = this;
-    $('div#list_container').on('click', 'a#randomFilm', function(e) {
+    $('#icme_random_film').on('click', function(e) {
         e.preventDefault();
         that.pickRandomFilm();
     });
@@ -465,15 +475,7 @@ UpcomingAwardsList.prototype.attach = function() {
     statistics += getSpan('Bronze', 0.5) + getSpan('Silver', 0.75) +
                   getSpan('Gold', 0.9) + getSpan('Platinum', 1);
 
-    if ($('div#list_container').length !== 1) {
-        var container =
-            '<div id="list_container" style="height: 35px; position: relative">' +
-                statistics + '</div>';
-
-        $('#movies').parent().before(container);
-    } else {
-        $('div#list_container').append(statistics);
-    }
+    addToMovieListBar(statistics);
 };
 
 UpcomingAwardsList.prototype.settings = {
@@ -1592,23 +1594,11 @@ LargeList.prototype.attach = function() {
     var link = '<span style="float: right; margin-left: 15px">' +
         '<a id="icme_large_posters" href="#">Large posters</a></span>';
 
-    if ($('div#list_container').length !== 1) {
-        var container = '<div id="list_container" style="height: 35px; ' +
-            'position: relative">' + link + '</div>';
-
-        $('#movies').parent().before(container);
-    } else {
-        if ($('#list_container').find('p').length === 1) {
-            $('#list_container p:first').append('<span> &mdash; </span>' + link);
-        } else {
-            $('div#list_container').append(link);
-        }
-    }
+    addToMovieListBar(link);
 
     var that = this;
     $('#icme_large_posters').on('click', function(e) {
         e.preventDefault();
-
         that.load();
     });
 };

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -382,6 +382,13 @@ RandomFilmLink.prototype.attach = function() {
         return;
     }
 
+    // Disable on completed lists and list of checked/favs.
+    // If a user unchecks smth., the link will show up only after reloading,
+    // but it's a rare case.
+    if (!$('ol#itemListMovies > li.unchecked').length) {
+        return;
+    }
+
     var randomFilm =
         '<span style="float:right; margin-left: 15px">' +
             '<a href="#" id="icme_random_film">Help me pick a film!</a></span>';
@@ -393,10 +400,19 @@ RandomFilmLink.prototype.attach = function() {
         e.preventDefault();
         that.pickRandomFilm();
     });
+
+    // Allow resetting visible movies on /movies/watchlist/ etc. by clicking on tab's label
+    var $activeTab = $('.tabMenu > .active');
+    if (!$activeTab.find('a').length) {
+        $activeTab.on('click', function() {
+            $('ol#itemListMovies > li').show();
+        });
+    }
 };
 
 // Displays a random film on a list
 RandomFilmLink.prototype.pickRandomFilm = function() {
+    // Recalc in case user has checked smth. while on a page
     var $unchecked = $('ol#itemListMovies > li.unchecked'),
         randNum;
 
@@ -427,7 +443,8 @@ RandomFilmLink.prototype.pickRandomFilm = function() {
 
 RandomFilmLink.prototype.settings = {
     title: 'Random film link',
-    desc: 'Displays "Help me pick a film" link on individual lists',
+    desc: 'Displays "Help me pick a film" link on movie lists (if they have unchecked movies).' +
+        '<br>Click on a list tab\'s label to return to full list.',
     index: 'random_film',
     includes: ['icheckmovies.com/lists/(.+)'],
     excludes: ['icheckmovies.com/lists/$'],

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -1373,24 +1373,31 @@ function HideTags(config) {
 }
 
 HideTags.prototype.attach = function() {
-    if (this.config.enabled) {
-        gmAddStyle(
-            'ol#itemListToplists li .info:last-child, ' +
-            'ol#itemListMovies li .tagList ' +
-                '{ display: none !important; }');
+    if (!this.config.enabled) {
+        return;
+    }
 
-        if (this.config.show_hover) {
-            gmAddStyle(
-                'ol#itemListToplists li:hover .info:last-child, ' +
-                'ol#itemListMovies li:hover .tagList ' +
-                    '{ display: block !important; }');
-        }
+    if (this.config.list_tags) {
+        // /movies/<title>/rankings/ and /lists/ have different structure
+        gmAddStyle('ol#itemListToplists > li > .info:last-child, ' +
+                   'ol#itemListToplists > li > .tagList { display: none !important; }');
+    }
+
+    if (this.config.movie_tags) {
+        gmAddStyle('ol#itemListMovies > li > .tagList { display: none !important; }');
+    }
+
+    if (this.config.show_hover) {
+        gmAddStyle(
+            'ol#itemListToplists li:hover .info:last-child, ' +
+            'ol#itemListMovies li:hover .tagList ' +
+                '{ display: block !important; }');
     }
 };
 
 HideTags.prototype.settings = {
     title: 'Hide tags',
-    desc: 'Hides tags on individual lists',
+    desc: 'Hides tags on movie lists and lists of lists',
     index: 'hide_tags',
     includes: ['icheckmovies.com/'],
     excludes: [],
@@ -1400,8 +1407,21 @@ HideTags.prototype.settings = {
         type: 'checkbox',
         default: false
     }, {
+        name: 'list_tags',
+        frontDesc: 'Hide on: ',
+        desc: 'lists',
+        type: 'checkbox',
+        inline: true,
+        default: true
+    }, {
+        name: 'movie_tags',
+        desc: 'movies',
+        type: 'checkbox',
+        inline: true,
+        default: true
+    }, {
         name: 'show_hover',
-        desc: 'Show tags when moving the cursor over a movie',
+        desc: 'Show tags when moving the cursor over a movie or a list',
         type: 'checkbox',
         default: false
     }]

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -1378,19 +1378,22 @@ HideTags.prototype.attach = function() {
     }
 
     if (this.config.list_tags) {
-        // /movies/<title>/rankings/ and /lists/ have different structure
-        gmAddStyle('ol#itemListToplists > li > .info:last-child, ' +
-                   'ol#itemListToplists > li > .tagList { display: none !important; }');
+        // /lists/ and /movies/<title>/rankings/ have different structure
+        gmAddStyle('ol#itemListToplists.listViewNormal > li > .info:last-child' + ', ' +
+                   'ol#itemListToplists > li > .tagList ' +
+                   '{ display: none !important; }');
     }
 
     if (this.config.movie_tags) {
-        gmAddStyle('ol#itemListMovies > li > .tagList { display: none !important; }');
+        gmAddStyle('ol#itemListMovies.listViewNormal > li > .tagList ' +
+                   '{ display: none !important; }');
     }
 
     if (this.config.show_hover) {
         gmAddStyle(
-            'ol#itemListToplists li:hover .info:last-child, ' +
-            'ol#itemListMovies li:hover .tagList ' +
+            'ol#itemListToplists.listViewNormal > li:hover > .info:last-child' + ', ' +
+            'ol#itemListToplists > li:hover > .tagList' + ', ' +
+            'ol#itemListMovies.listViewNormal > li:hover > .tagList ' +
                 '{ display: block !important; }');
     }
 };

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -567,12 +567,7 @@ UpcomingAwardsOverview.prototype.populateLists = function() {
                 return false; // exit loop; the order of array is important!
             }
 
-            that.lists.push({
-                awardChecks: awardChecks,
-                awardType:   award[0],
-                listTitle:   listTitle,
-                listUrl:     listUrl
-            });
+            that.lists.push({ awardChecks, listTitle, listUrl, awardType: award[0] });
         });
     });
 };
@@ -1074,15 +1069,15 @@ ListCrossCheck.prototype.updateMovies = function($content) {
         var found = false,
             $movie = $(this),
             $movieTitle = $movie.find('h2'),
-            curTitle = $movieTitle.text().trim(),
-            curUrl = $movieTitle.find('a').attr('href'),
-            curYear = $movieTitle.next('span.info').children('a:first').text();
+            title = $movieTitle.text().trim(),
+            url = $movieTitle.find('a').attr('href'),
+            year = $movieTitle.next('span.info').children('a:first').text();
 
         for (var movieObj of that.movies) {
             // compare urls as they're guaranteed to be unique
             // in some cases movie title and release year are the same for different movies
             // which results in incorrect top list values
-            if (curUrl === movieObj.url) {
+            if (url === movieObj.url) {
                 movieObj.count += 1;
                 movieObj.jq.find('.rank').html(movieObj.count);
                 found = true;
@@ -1106,13 +1101,7 @@ ListCrossCheck.prototype.updateMovies = function($content) {
                 $movie.removeClass('notowned').addClass('owned');
             }
 
-            that.movies.push({
-                title: curTitle,
-                count: 1,
-                url: curUrl,
-                year: curYear,
-                jq: $movie
-            });
+            that.movies.push({ title, url, year, count: 1, jq: $movie });
         }
     });
 
@@ -1750,9 +1739,9 @@ ListOverviewSort.prototype.rearrange = function(order, section) {
     var toplistArr = $toplistItems.toArray();
 
     if (this.config.autosort) {
-        var lookupMap = toplistArr.map(function(item, i) {
+        var lookupMap = toplistArr.map(function(item, index) {
             var width = $(item).find('span.progress').css('width').replace('px', '');
-            return { index: i, value: parseFloat(width) };
+            return { index, value: parseFloat(width) };
         });
 
         lookupMap.sort(function(a, b) {
@@ -2091,11 +2080,11 @@ function ProgressTopX(config) {
 
 ProgressTopX.prototype.attach = function() {
     if (this.config.enabled) {
-        var css = 'float: left; margin-right: 0.5em',
-            attr = { text: 'Load stats', id: 'icme_req_for_top', href: '#', style: css },
+        var style = 'float: left; margin-right: 0.5em',
+            attr = { style, text: 'Load stats', id: 'icme_req_for_top', href: '#' },
             // can't pass the value directly in case of user changing it and not reloading
             $loadLink = $('<a>', attr).click({ cfg: this.config }, this.addStats),
-            $spanElem = $('<span>', { text: ' | ', style: css });
+            $spanElem = $('<span>', { style, text: ' | ' });
 
         $('#listOrderingWrapper').prepend($loadLink, $spanElem);
     }

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -2066,7 +2066,7 @@ ExportLists.prototype.attach = function() {
                 title = encodeField($item.find('h2>a').text()),
                 aka = encodeField($item.find('.info > em').text()),
                 year = $item.find('.info a:first').text(),
-                toplists = parseInt($item.find('.info a:last').text(), 10),
+                toplists = parseInt($item.find('.info a:nth-of-type(2)').text(), 10),
                 checked = $item.hasClass('checked') ? 'yes' : 'no',
                 isFav = $item.hasClass('favorite') ? 'yes' : 'no',
                 isDislike = $item.hasClass('hated') ? 'yes' : 'no',
@@ -2078,9 +2078,10 @@ ExportLists.prototype.attach = function() {
 
         // BOM with ; or , as separator and without sep= - for Excel
         var bom = _c.bom ? '\uFEFF' : '',
-            dataURI = 'data:text/csv;charset=utf-8,' + bom + encodeURIComponent(data);
+            dataURI = 'data:text/csv;charset=utf-8,' + bom + encodeURIComponent(data),
+            filename = $('#topList>h1').text().trim() || $('#listTitle > h1').text().trim();
         // link swapping with a correct filename - http://caniuse.com/download
-        $(this).attr('href', dataURI).attr('download', $('#topList>h1').text() + '.csv');
+        $(this).attr('href', dataURI).attr('download', filename + '.csv');
 
         // after changing URL jQuery fires a default click event
         // on the link user clicked on, and loads dataURI as URL (!)

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -79,6 +79,22 @@ function evalOrParse(str) {
     }
 }
 
+/**
+ * Create a necessary BaseFeature-settings-options item that defines
+ * whether or not a module should be loaded by default.
+ * (Should be a BaseFeature method, but the way settings are defined makes it hard.)
+ *
+ * @param {boolean} isEnabled
+ */
+function getDefState(isEnabled) {
+    return {
+        name: 'enabled',
+        desc: 'Enabled',
+        type: 'checkbox',
+        default: isEnabled
+    };
+}
+
 // ----- Interacting with ICM -----
 
 // mutually exclusive regexes for matching page type
@@ -424,10 +440,6 @@ function RandomFilmLink(config) {
 
 // Creates an element and inserts it into the DOM
 RandomFilmLink.prototype.attach = function() {
-    if (!this.config.enabled) {
-        return;
-    }
-
     // Disable on completed lists and list of checked/favs.
     // If a user unchecks smth., the link will show up only after reloading,
     // but it's a rare case.
@@ -493,12 +505,7 @@ RandomFilmLink.prototype.settings = {
         '<br>Click on a list tab\'s label to return to full list.',
     index: 'random_film',
     enableOn: ['movieList', 'movieListSpecial'], // movieListGeneral doesn't make sense here
-    options: [{
-        name: 'enabled',
-        desc: 'Enabled',
-        type: 'checkbox',
-        default: true
-    }, {
+    options: [getDefState(true), {
         name: 'unique',
         desc: 'Unique suggestions (shows each entry only once ' +
               'until every entry has been shown once)',
@@ -516,7 +523,7 @@ function UpcomingAwardsList(config) {
 }
 
 UpcomingAwardsList.prototype.attach = function() {
-    if (!this.config.enabled || !$('#itemListMovies').length) {
+    if (!$('#itemListMovies').length) {
         return;
     }
 
@@ -545,12 +552,7 @@ UpcomingAwardsList.prototype.settings = {
     desc: 'Displays upcoming awards on individual lists',
     index: 'ua_list',
     enableOn: ['movieList'],
-    options: [{
-        name: 'enabled',
-        desc: 'Enabled',
-        type: 'checkbox',
-        default: true
-    }, {
+    options: [getDefState(true), {
         name: 'show_absolute',
         desc: 'Display negative values',
         type: 'checkbox',
@@ -570,10 +572,6 @@ function UpcomingAwardsOverview(config) {
 }
 
 UpcomingAwardsOverview.prototype.attach = function() {
-    if (!this.config.enabled) {
-        return;
-    }
-
     if (this.config.autoload) {
         this.loadAwardData();
         return;
@@ -851,12 +849,7 @@ UpcomingAwardsOverview.prototype.settings = {
     desc: 'Displays upcoming awards on progress page',
     index: 'ua',
     enableOn: ['listsSpecial', 'progress'],
-    options: [{
-        name: 'enabled',
-        desc: 'Enabled',
-        type: 'checkbox',
-        default: true
-    }, {
+    options: [getDefState(true), {
         name: 'autoload',
         desc: 'Autoload',
         type: 'checkbox',
@@ -873,10 +866,6 @@ function ListCustomColors(config) {
 }
 
 ListCustomColors.prototype.attach = function() {
-    if (!this.config.enabled) {
-        return;
-    }
-
     function buildCSS(className, color) {
         if (!color.length) {
             return;
@@ -901,12 +890,7 @@ ListCustomColors.prototype.settings = {
           'your favorites/watchlist/dislikes',
     index: 'list_colors',
     enableOn: ['movieList', 'movieListGeneral', 'movieListSpecial', 'movieSearch'],
-    options: [{
-        name: 'enabled',
-        desc: 'Enabled',
-        type: 'checkbox',
-        default: true
-    }, {
+    options: [getDefState(true), {
         name: 'colors.favorite',
         desc: 'Favorites',
         type: 'textinputcolor',
@@ -958,7 +942,7 @@ ListCrossCheck.prototype.init = function() {
 };
 
 ListCrossCheck.prototype.attach = function() {
-    if (!this.config.enabled || $('#itemListToplists').length === 0) {
+    if (!$('#itemListToplists').length) {
         return;
     }
 
@@ -1378,12 +1362,7 @@ ListCrossCheck.prototype.settings = {
     desc: 'Cross-reference lists to find what films they share',
     index: 'list_cross_ref',
     enableOn: ['listsGeneral', 'listsSpecial'],
-    options: [{
-        name: 'enabled',
-        desc: 'Enabled',
-        type: 'checkbox',
-        default: false
-    }, {
+    options: [getDefState(true), {
         name: 'match_all',
         desc: 'Find films that appear on all selected lists',
         type: 'checkbox',
@@ -1410,10 +1389,6 @@ function HideTags(config) {
 }
 
 HideTags.prototype.attach = function() {
-    if (!this.config.enabled) {
-        return;
-    }
-
     if (this.config.list_tags) {
         // /lists/ and /movies/<title>/rankings/ have different structure
         gmAddStyle('ol#itemListToplists.listViewNormal > li > .info:last-child' + ', ' +
@@ -1442,12 +1417,7 @@ HideTags.prototype.settings = {
     // ICM bug: movieListGeneral and movieSearch never have tags
     enableOn: ['listsGeneral', 'listsSpecial', 'listsSearch',
         'movieList', 'movieListGeneral', 'movieListSpecial', 'movieSearch', 'movieRankings'],
-    options: [{
-        name: 'enabled',
-        desc: 'Enabled',
-        type: 'checkbox',
-        default: false
-    }, {
+    options: [getDefState(false), {
         name: 'list_tags',
         frontDesc: 'Hide on: ',
         desc: 'lists',
@@ -1477,10 +1447,6 @@ function WatchlistTab(config) {
 }
 
 WatchlistTab.prototype.attach = function() {
-    if (!this.config.enabled) {
-        return;
-    }
-
     var $movies = $('#itemListMovies');
     if ($movies.length === 0) {
         return;
@@ -1522,12 +1488,7 @@ WatchlistTab.prototype.settings = {
     desc: 'Creates a tab on lists that shows watchlist entries.',
     index: 'watchlist_tab',
     enableOn: ['movieList'],
-    options: [{
-        name: 'enabled',
-        desc: 'Enabled',
-        type: 'checkbox',
-        default: false
-    }]
+    options: [getDefState(false)]
 };
 
 // Inherit methods from BaseFeature
@@ -1539,10 +1500,6 @@ function Owned(config) {
 }
 
 Owned.prototype.attach = function() {
-    if (!this.config.enabled) {
-        return;
-    }
-
     var $movielist = $('#itemListMovies'),
         $markOwned = $('.optionMarkOwned');
     // Check if 'owned' button exists
@@ -1635,12 +1592,7 @@ Owned.prototype.settings = {
     index: 'owned_tab',
     enableOn: ['movieList', 'movieListGeneral', 'movieListSpecial', 'movieSearch',
         'movie', 'movieRankings'],
-    options: [{
-        name: 'enabled',
-        desc: 'Enabled',
-        type: 'checkbox',
-        default: false
-    }, {
+    options: [getDefState(false), {
         name: 'free_account',
         desc: 'I have a free account (must uncheck if you have a paid account)',
         type: 'checkbox',
@@ -1659,10 +1611,6 @@ function LargeList(config) {
 }
 
 LargeList.prototype.attach = function() {
-    if (!this.config.enabled) {
-        return;
-    }
-
     if (this.config.autoload) {
         this.load();
         return;
@@ -1746,12 +1694,7 @@ LargeList.prototype.settings = {
     desc: 'Display large posters on individual lists (large posters are lazy loaded)',
     index: 'large_lists',
     enableOn: ['movieList', 'movieListGeneral', 'movieListSpecial'],
-    options: [{
-        name: 'enabled',
-        desc: 'Enabled',
-        type: 'checkbox',
-        default: true
-    }, {
+    options: [getDefState(true), {
         name: 'autoload',
         desc: 'Autoload',
         type: 'checkbox',
@@ -1768,10 +1711,6 @@ function ListOverviewSort(config) {
 }
 
 ListOverviewSort.prototype.attach = function() {
-    if (!this.config.enabled) {
-        return;
-    }
-
     if (this.config.single_col) {
         gmAddStyle('.itemList .listItem.listItemProgress { float: none !important; }');
     }
@@ -1881,12 +1820,7 @@ ListOverviewSort.prototype.settings = {
     desc: 'Change the order of lists on the progress page',
     index: 'toplists_sort',
     enableOn: ['progress'],
-    options: [{
-        name: 'enabled',
-        desc: 'Enabled',
-        type: 'checkbox',
-        default: false
-    }, {
+    options: [getDefState(false), {
         name: 'autosort',
         desc: 'Sort lists by completion rate',
         type: 'checkbox',
@@ -1928,10 +1862,6 @@ function ListsTabDisplay(config) {
 }
 
 ListsTabDisplay.prototype.attach = function() {
-    if (!this.config.enabled) {
-        return;
-    }
-
     var isOnMoviePage = reICM.movieRankings.test(window.location.href),
         _c = this.config;
 
@@ -2016,12 +1946,7 @@ ListsTabDisplay.prototype.settings = {
     index: 'lists_tab_display',
     enableOn: ['movieList', 'movieListGeneral', 'movieListSpecial',
         'movieRankings', 'movieSearch'],
-    options: [{
-        name: 'enabled',
-        desc: 'Enabled',
-        type: 'checkbox',
-        default: true
-    }, {
+    options: [getDefState(true), {
         name: 'redirect',
         desc: 'Redirect "in # lists" movie links to "All" lists tab',
         type: 'checkbox',
@@ -2067,10 +1992,6 @@ function ExportLists(config) {
 }
 
 ExportLists.prototype.attach = function() {
-    if (!this.config.enabled) {
-        return;
-    }
-
     var _c = this.config,
         sep = _c.delimiter;
 
@@ -2124,12 +2045,7 @@ ExportLists.prototype.settings = {
           'Emulates the paid feature, so don\'t enable it if you have a paid account',
     index: 'export_lists',
     enableOn: ['movieList', 'movieListSpecial'],
-    options: [{
-        name: 'enabled',
-        desc: 'Enabled',
-        type: 'checkbox',
-        default: false
-    }, {
+    options: [getDefState(false), {
         name: 'delimiter',
         desc: 'Use as delimiter (accepts \';\' or \',\'; otherwise uses \\t)',
         type: 'textinput',
@@ -2151,10 +2067,6 @@ function ProgressTopX(config) {
 }
 
 ProgressTopX.prototype.attach = function() {
-    if (!this.config.enabled) {
-        return;
-    }
-
     var style = 'float: left; margin-right: 0.5em',
         attr = { style, text: 'Load stats', id: 'icme_req_for_top', href: '#' },
         // can't pass the value directly in case of user changing it and not reloading
@@ -2199,12 +2111,7 @@ ProgressTopX.prototype.settings = {
     desc: 'Find out how many checks you need to get into Top 25/50/100/1000/...',
     index: 'progress_top_x',
     enableOn: ['progress'],
-    options: [{
-        name: 'enabled',
-        desc: 'Enabled',
-        type: 'checkbox',
-        default: true
-    }, {
+    options: [getDefState(true), {
         name: 'target_page',
         desc: 'Ranking page you want to be on (page x 25 = rank)',
         type: 'textinput',
@@ -2231,8 +2138,12 @@ Enhanced.prototype.register = function(Module) {
 Enhanced.prototype.load = function() {
     for (var m of this.modules) {
         if (m.matchesUrl()) {
-            console.log('Attaching ' + m.constructor.name);
-            m.attach();
+            if (m.config.enabled) {
+                console.log('Attaching ' + m.constructor.name);
+                m.attach();
+            } else {
+                console.log('Skipping ' + m.constructor.name);
+            }
         }
     }
 

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -1941,7 +1941,7 @@ ListsTabDisplay.prototype.attach = function() {
         // visual fix for edge cases when all lists are moved
         lists.last().filter('.groupSeparator').hide();
     } else if (_c.redirect) { // = if on a list page
-        var $linksToLists = $('.listItemMovie > .info > a:last-of-type');
+        var $linksToLists = $('.listItemMovie > .info > a:nth-of-type(2)');
 
         $linksToLists.each(function() {
             var $link = $(this),

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -2,7 +2,7 @@
 // @name           iCheckMovies Enhanced
 // @namespace      iCheckMovies
 // @description    Adds new features to enhance the iCheckMovies user experience
-// @version        1.7.7
+// @version        1.7.8
 // @include        http://icheckmovies.com*
 // @include        http://www.icheckmovies.com*
 // @include        https://icheckmovies.com*


### PR DESCRIPTION
Hi!

Another batch of fixes and refactorings. The main one is that modules no longer have to include regexes for page matching in their settings, only keys for an object of narrow mutually exclusive regexes for different page types. You can still use the old system of specifying extra regexes in `includes` and `excludes` arrays if you need to fine-tune, but most cases should be covered by new page types.

As a result, many modules now work only on pages they are supposed to work. Also the code for checking module state is no longer duplicated in every module.

Since I wanted to split HideTags between movies and lists, I added a way to place options inline (`frontDesc` and `inline` keys of option-objects in module settings). And the code for a row of the script's stats and links is extracted into an utility function.

Tested in FF+GM and Chrome+TM.

Other fixes:
10dabf0e56a8dd7db79b5f00158b2743ad3a9de2 - Random film link, Large posters, Export lists: now work on a watchlist/favs/checked movies/etc. (but exporting downloads only a single page)
b4f20e66b69c8eb643882577e73b381da2274917 - Random film link: disable on completed lists, allow returning to a full list when using on a watchlist/favs/etc.
f30d6a26b799800dba10cbc1897491960000647a - Hide tags: separate options for hiding tags of movies and lists; hide tags also on /movies/\<movie-name\>/rankings/
dcf6e09b7520149bd87bfaab5c9406990e1f5603 - Hide tags: don't show tags when hovering in compact mode
13381cbe0a6ef16d76e45bb2441039e06cc158d2 - Lists tab display: links on /movies/checked/ didn't redirect properly
