### PR TITLE
Another batch of fixes

### DIFF
--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -667,7 +667,7 @@ UpcomingAwardsOverview.prototype.sortLists = function() {
  * and only if this module is attached.
  */
 UpcomingAwardsOverview.prototype.getIconFactory = function() {
-    var unhideIconData = 'data:text/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAA' +
+    var unhideIconData = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAA' +
         'AQCAYAAAAf8/9hAAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW' +
         '1hZ2VSZWFkeXHJZTwAAAGrSURBVDjLvZPZLkNhFIV75zjvYm7VGFNCqoZUJ+roKUUpjR' +
         'uqp61Wq0NKDMelGGqOxBSUIBKXWtWGZxAvobr8lWjChRgSF//dv9be+9trCwAI/vIE/2' +
@@ -679,7 +679,7 @@ UpcomingAwardsOverview.prototype.getIconFactory = function() {
         'ZaUrCSIi6X+jJIBBYtW5Cge7cd7sgoHDfDaAvKQGAlRZYc6ltJlMxX03UzlaRlBdQrzS' +
         'CwksLRbOpHUSb7pcsnxCCwngvM2Rm/ugUCi84fycr4l2t8Bb6iqTxSCgNIAAAAAElFTk' +
         'SuQmCC',
-        hideIconData = 'data:text/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAK' +
+        hideIconData = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAK' +
         'CAYAAACNMs+9AAAABGdBTUEAAK/INwWK6QAAABl0RVh0U29mdHdhcmUAQWRvYmUgSW1h' +
         'Z2VSZWFkeXHJZTwAAADtSURBVHjajFC7DkFREJy9iXg0t+EHRKJDJSqRuIVaJT7AF+jR' +
         '+xuNRiJyS8WlRaHWeOU+kBy7eyKhs8lkJrOzZ3OWzMAD15gxYhB+yzAm0ndez+eYMYLn' +

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -1636,33 +1636,39 @@ LargeList.prototype.load = function() {
 
     this.loaded = true;
 
-    var style =
-        '#itemListMovies > .listItem ' +
-            '{ float:left; height: 330px; width: 255px; } ' +
-        '.listItem .listImage ' +
+    // make sure normal view is enabled
+    this.enableNormalView();
+
+    var root = '#itemListMovies.listViewNormal',
+        style =
+        root + ' > .listItem ' +
+            '{ float:left; width: 255px; } ' +
+        root + ' .listItem .listImage ' +
             '{ float:none; width: 230px; height: 305px; left:-18px; top:-18px; margin:0; } ' +
-        '.listImage a ' +
+        root + ' .listImage a ' +
             '{ width:100%; height:100%; background: url("/images/dvdCover.png") ' +
             'no-repeat scroll center center transparent; } ' +
-        '.listImage .coverImage ' +
+        root + ' .listImage .coverImage ' +
             '{ width:190px; height:258px; top:21px; left: 19px; right:auto; } ' +
-        '.listItem .rank ' +
+        root + ' .listItem .rank ' +
             '{ top: 15px; position:absolute; height:auto; width:65px; ' +
             'right:0; margin:0; font-size:30px; } ' +
-        '.listItem .rank .positiondifference span ' +
+        root + ' .listItem .rank .positiondifference span ' +
             '{ font-size: 12px; } ' +
-        '.listItem h2 ' +
+        root + ' .listItem h2 ' +
             '{ z-index:11; font-size:14px; width:100%; margin:-30px 0 0 0; } ' +
-        '.listItem .info ' +
+        root + ' .listItem .info ' +
             '{ font-size:12px; width:100%; height:auto; line-height:16px; margin-top:4px; } ' +
-        '.checkbox ' +
+        root + ' .checkbox ' +
             '{ top:85px; right:12px; } ' +
-        '#itemListMovies .optionIconMenu ' +
+        root + ' .optionIconMenu ' +
             '{ top:120px; right:20px; } ' +
-        '#itemListMovies .optionIconMenu li ' +
+        root + ' .optionIconMenu li ' +
             '{ display: block; } ' +
-        '#itemListMovies .optionIconMenuCheckbox ' +
-            '{ right:20px; }';
+        root + ' .optionIconMenuCheckbox ' +
+            '{ right:20px; }' +
+        '#itemListMovies.listViewCompact > .listItem' +
+            '{ height: auto; }';
 
     style = style.replace(/;/g, ' !important;');
 
@@ -1687,6 +1693,29 @@ LargeList.prototype.load = function() {
     }
 
     $('img.coverImage').lazyload({ threshold: 200 });
+    this.adjustHeights(); // tags and long titles can increase item's height
+};
+
+LargeList.prototype.enableNormalView = function() {
+    var $normalViewSwitch = $('#listViewNormal').find('a');
+    if (!$normalViewSwitch.hasClass('active')) {
+        // copied from ICM source code
+        $('#listViewCompact').find('a').removeClass('active');
+        $normalViewSwitch.addClass('active');
+        $('ol.itemList')
+            .removeClass('listViewCompact')
+            .addClass('listViewNormal');
+    }
+};
+
+LargeList.prototype.adjustHeights = function() {
+    $('.listItemMovie:nth-child(3n-2)').each(function() {
+        var $t = $(this),
+            $t2 = $t.next(),
+            $t3 = $t2.next(),
+            maxHeight = Math.max($t.height(), $t2.height(), $t3.height());
+        $t.add($t2).add($t3).height(maxHeight);
+    });
 };
 
 LargeList.prototype.settings = {

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -1252,7 +1252,8 @@ ListCrossCheck.prototype.outputMovies = function() {
             e.preventDefault();
 
             var data = '"found_toplists","title","year","official_toplists","imdb"\n',
-                $items = $('#itemListMovies').children('li');
+                // target only the list below the button (in case there are several)
+                $items = $(this).parents('.tabMenu').next('.itemList').children('li');
 
             $items.each(function() {
                 var $item = $(this),

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -893,7 +893,8 @@ ListCustomColors.prototype.settings = {
     desc: 'Changes entry colors on lists to visually separate ' +
           'your favorites/watchlist/dislikes',
     index: 'list_colors',
-    enableOn: ['movieList', 'movieListGeneral', 'movieListSpecial', 'movieSearch'],
+    enableOn: ['movieList', 'movieListGeneral', 'movieListSpecial', 'movieSearch',
+        'listsGeneral', 'listsSpecial'],
     options: [getDefState(true), {
         name: 'colors.favorite',
         desc: 'Favorites',
@@ -934,9 +935,6 @@ ListCrossCheck.prototype.init = function() {
 
     // array of top list jQuery elements
     this.$toplists = [];
-
-    // number of total toplists
-    this.numToplists = 0;
 
     // cross-referencing in progress
     this.inProgress = false;
@@ -1053,7 +1051,6 @@ ListCrossCheck.prototype.check = function() {
     // get selected top lists
     var $toplists = $toplistCont.children('li.icme_listcc');
 
-    this.numToplists = $toplists.length;
     this.inProgress = true;
 
     // sort selected top lists in ascending order by number of unchecked films

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -572,6 +572,10 @@ function UpcomingAwardsOverview(config) {
 }
 
 UpcomingAwardsOverview.prototype.attach = function() {
+    if (!$('.listItemToplist').length) {
+        return;
+    }
+
     if (this.config.autoload) {
         this.loadAwardData();
         return;

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -636,16 +636,16 @@ UpcomingAwardsOverview.prototype.populateLists = function() {
 
 UpcomingAwardsOverview.prototype.sortLists = function() {
     // sort lists array by least required checks ASC,
-    // then by awards where checks are equal ASC, then by list title ASC
+    // then by award type if checks are equal DESC, then by list title ASC
     var awardOrder = { Bronze: 0, Silver: 1, Gold: 2, Platinum: 3 };
     this.lists.sort(function(a, b) {
         if (a.neededForAward < b.neededForAward) {
             return -1;
         } else if (a.neededForAward > b.neededForAward) {
             return 1;
-        } else if (awardOrder[a.awardType] < awardOrder[b.awardType]) {
-            return -1;
         } else if (awardOrder[a.awardType] > awardOrder[b.awardType]) {
+            return -1;
+        } else if (awardOrder[a.awardType] < awardOrder[b.awardType]) {
             return 1;
         } else if (a.listTitle < b.listTitle) {
             return -1;

--- a/icm-enhanced.user.js
+++ b/icm-enhanced.user.js
@@ -2,7 +2,7 @@
 // @name           iCheckMovies Enhanced
 // @namespace      iCheckMovies
 // @description    Adds new features to enhance the iCheckMovies user experience
-// @version        1.7.8
+// @version        1.7.9
 // @include        http://icheckmovies.com*
 // @include        http://www.icheckmovies.com*
 // @include        https://icheckmovies.com*


### PR DESCRIPTION
Some further tweaks for page type matching and a couple of issues I've wanted to fix for a while.

Large posters: now works with compact list view; tags are no longer cropped
Upcoming awards overview: awards with the same number of remaining checks are sorted by award type in a desc order (from Platinum to Bronze)
Upcoming awards overview: table is hidden if a page has no lists
Custom list colors: last update broke custom highlighting on cross-ref'd lists
List cross-reference: fixed exporting if there is more than one cross-ref list on a page
Lists tab display: also redirects links in cross-ref lists